### PR TITLE
Setters

### DIFF
--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -72,7 +72,7 @@ namespace pardibaal {
 
     bool DBM::is_unbounded() const {
         for (dim_t i = 1; i < dimension(); ++i)
-            if (not this->at(i, 0)._inf)
+            if (not this->at(i, 0).is_inf())
                 return false;
 
         return true;

--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -74,9 +74,9 @@ namespace pardibaal {
         // For each clock:
         // Check that upper and lower bounds are non-strict and that the bounds are the same (absolute value)
         for (dim_t i = 1; i < dimension(); ++i) {
-            if (this->at(0, i)._inf != this->at(i, 0)._inf)
+            if (this->at(0, i).is_inf() != this->at(i, 0).is_inf())
                 continue;
-            if (!this->at(0, i)._strict && !this->at(i, 0)._strict && -this->at(0, i)._n == this->at(i, 0)._n)
+            if (this->at(0, i).is_non_strict() && this->at(i, 0).is_non_strict() && -this->at(0, i).get_bound() == this->at(i, 0).get_bound())
                 return false;
         }
 
@@ -95,15 +95,15 @@ namespace pardibaal {
 
     void DBM::future() {
         for (dim_t i = 1; i < this->dimension(); ++i)
-            _bounds_table.at(i, 0) = bound_t::inf();
+            _bounds_table.set(i, 0, bound_t::inf());
     }
 
     void DBM::past() {
         for (dim_t i = 1; i < this->dimension(); ++i) {
-            this->_bounds_table.at(0, i) = bound_t::zero();
+            this->_bounds_table.set(0, i, bound_t::zero());
             for (dim_t j = 1; j < this->dimension(); ++j) {
                 if (this->_bounds_table.at(j, i) < this->_bounds_table.at(0, i)) {
-                    this->_bounds_table.at(0, i) = this->_bounds_table.at(j, i);
+                    this->_bounds_table.set(0, i, this->_bounds_table.at(j, i));
                 }
             }
         }
@@ -111,7 +111,7 @@ namespace pardibaal {
 
     void DBM::restrict(dim_t x, dim_t y, bound_t g) {
         if ((_bounds_table.at(y, x) + g) < bound_t::zero()) // In this case the zone is now empty
-            _bounds_table.at(0, 0) = bound_t::non_strict(-1);
+            _bounds_table.set(0, 0, bound_t::non_strict(-1));
         else if (g < _bounds_table.at(x, y)) {
             _bounds_table.set(x, y, g);
             for (dim_t i = 0; i < this->dimension(); ++i) {
@@ -178,10 +178,10 @@ namespace pardibaal {
         for (dim_t i = 0; i < this->dimension(); ++i) {
             for (dim_t j = 0; j < this->dimension(); ++j) {
                 if (!this->_bounds_table.at(i, j).is_inf() && this->_bounds_table.at(i, j) > bound_t::non_strict(ceiling[i])){
-                    this->_bounds_table.at(i, j) = bound_t::inf();
+                    this->_bounds_table.set(i, j, bound_t::inf());
                 }
                 else if (!this->_bounds_table.at(i, j).is_inf() && this->_bounds_table.at(i, j) < bound_t::strict(-ceiling[j])) {
-                    this->_bounds_table.at(i, j) = bound_t::strict(-ceiling[j]);
+                    this->_bounds_table.set(i, j, bound_t::strict(-ceiling[j]));
                 }
             }
         }
@@ -302,7 +302,7 @@ namespace pardibaal {
                 if (i == c && i < dimension() -1) {++i;}
                 if (j == c || i == c) continue;
 
-                D.at(i2, j2++) = this->at(i, j);
+                D.set(i2, j2++, this->at(i, j));
             }
         }
 

--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -177,11 +177,11 @@ namespace pardibaal {
 
         for (dim_t i = 0; i < this->dimension(); ++i) {
             for (dim_t j = 0; j < this->dimension(); ++j) {
-                if (!this->_bounds_table.at(i, j)._inf && this->_bounds_table.at(i, j) > bound_t::non_strict(ceiling[i])){
-                    this->_bounds_table.set(i, j, bound_t::inf());
+                if (!this->_bounds_table.at(i, j).is_inf() && this->_bounds_table.at(i, j) > bound_t::non_strict(ceiling[i])){
+                    this->_bounds_table.at(i, j) = bound_t::inf();
                 }
-                else if (!this->_bounds_table.at(i, j)._inf && this->_bounds_table.at(i, j) < bound_t::strict(-ceiling[j])) {
-                    this->_bounds_table.set(i, j, bound_t::strict(-ceiling[j]));
+                else if (!this->_bounds_table.at(i, j).is_inf() && this->_bounds_table.at(i, j) < bound_t::strict(-ceiling[j])) {
+                    this->_bounds_table.at(i, j) = bound_t::strict(-ceiling[j]);
                 }
             }
         }

--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -24,7 +24,17 @@
 #include "errors.h"
 
 namespace pardibaal {
+
+    relation_t relation_t::equal() {return relation_t(true, true, true, false);}
+    relation_t relation_t::subset() {return relation_t(false, true, false, false);}
+    relation_t relation_t::superset() {return relation_t(false, false, true, false);}
+    relation_t relation_t::different() {return relation_t(false, false, false, true);}
+
     DBM::DBM(dim_t number_of_clocks) : _bounds_table(number_of_clocks) {}
+
+    bound_t DBM::at(dim_t i, dim_t j) const {return this->_bounds_table.at(i, j);}
+    void DBM::set(dim_t i, dim_t j, bound_t bound) {this->_bounds_table.set(i, j, bound);}
+    dim_t DBM::dimension() const {return this->_bounds_table.number_of_clocks();}
 
     bool DBM::is_empty() const {
         // Check if 0 - 0 is less than 0 (used for quicker identification of empty zone
@@ -69,6 +79,10 @@ namespace pardibaal {
 
         return relation_t::different();
     }
+
+    bool DBM::equal(const DBM& dbm) const {return this->relation(dbm)._equal;}
+    bool DBM::subset(const DBM& dbm) const {return this->relation(dbm)._subset;}
+    bool DBM::superset(const DBM& dbm) const {return this->relation(dbm)._superset;}
 
     bool DBM::is_unbounded() const {
         for (dim_t i = 1; i < dimension(); ++i)

--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -216,7 +216,7 @@ namespace pardibaal {
                     this->set(i, j, bound_t::inf());
                 }
                 else if (D.at(i, j) < bound_t::non_strict(-ceiling[j]) && i == 0)
-                    this->at(i, j) = bound_t::strict(-ceiling[j]);
+                    this->set(i, j, bound_t::strict(-ceiling[j]));
 
                 // Make sure we don't set 0, j to positive bound or i, 0 to a negative one
                 //TODO: We only do this because regular close() does not catch these.
@@ -247,9 +247,9 @@ namespace pardibaal {
             for (dim_t j = 0; j < D.dimension(); ++j) {
                 if (i == j) continue;
                 else if (D.at(i, j) > bound_t::non_strict(lower[i]))
-                    this->at(i, j) = bound_t::inf();
+                    this->set(i, j, bound_t::inf());
                 else if (D.at(i, j) < bound_t::non_strict(-upper[j]))
-                    this->at(i, j) = bound_t::strict(-upper[j]);
+                    this->set(i, j, bound_t::strict(-upper[j]));
 
                 // Make sure we don't set 0, j to positive bound or i, 0 to a negative one
                 //TODO: We only do this because regular close() does not catch these.
@@ -279,9 +279,9 @@ namespace pardibaal {
                 else if (D.at(i, j) > bound_t::non_strict(lower[i]) ||
                          D.at(0, i) < bound_t::non_strict(-lower[i]) ||
                          (D.at(0, j) < bound_t::non_strict(-upper[j]) && i != 0))
-                    this->at(i, j) = bound_t::inf();
+                    this->set(i, j, bound_t::inf());
                 else if (D.at(0, j) < bound_t::non_strict(-upper[j]) && i == 0)
-                    this->at(i, j) = bound_t::strict(-upper[j]);
+                    this->set(i, j, bound_t::strict(-upper[j]));
 
                 // Make sure we don't set 0, j to positive bound or i, 0 to a negative one
                 //TODO: We only do this because regular close() does not catch these.

--- a/src/pardibaal/DBM.h
+++ b/src/pardibaal/DBM.h
@@ -35,10 +35,10 @@ namespace pardibaal {
         relation_t(bool equal, bool subset, bool superset, bool different) :
             _equal(equal), _subset(subset), _superset(superset), _different(different) {}
 
-        [[nodiscard]] static inline relation_t equal() {return relation_t(true, true, true, false);}
-        [[nodiscard]] static inline relation_t subset() {return relation_t(false, true, false, false);}
-        [[nodiscard]] static inline relation_t superset() {return relation_t(false, false, true, false);}
-        [[nodiscard]] static inline relation_t different() {return relation_t(false, false, false, true);}
+        [[nodiscard]] static relation_t equal();
+        [[nodiscard]] static relation_t subset();
+        [[nodiscard]] static relation_t superset();
+        [[nodiscard]] static relation_t different();
     };
 
     class DBM {
@@ -47,17 +47,17 @@ namespace pardibaal {
     public:
         DBM(dim_t number_of_clocks);
 
-        [[nodiscard]] inline bound_t at(dim_t i, dim_t j) const {return this->_bounds_table.at(i, j);}
-        inline void set(dim_t i, dim_t j, bound_t bound) {this->_bounds_table.set(i, j, bound);}
-        [[nodiscard]] inline dim_t dimension() const {return this->_bounds_table.number_of_clocks();}
+        [[nodiscard]] bound_t at(dim_t i, dim_t j) const;
+        void set(dim_t i, dim_t j, bound_t bound);
+        [[nodiscard]] dim_t dimension() const;
 
         [[nodiscard]] bool is_empty() const;
         [[nodiscard]] bool is_satisfied(dim_t x, dim_t y, bound_t g) const;
         [[nodiscard]] relation_t relation(const DBM& dbm) const;
 
-        [[nodiscard]] inline bool equal(const DBM& dbm) const {return this->relation(dbm)._equal;}
-        [[nodiscard]] inline bool subset(const DBM& dbm) const {return this->relation(dbm)._subset;}
-        [[nodiscard]] inline bool superset(const DBM& dbm) const {return this->relation(dbm)._superset;}
+        [[nodiscard]] bool equal(const DBM& dbm) const;
+        [[nodiscard]] bool subset(const DBM& dbm) const;
+        [[nodiscard]] bool superset(const DBM& dbm) const;
 
         /** Is bounded
          * Checks whether all upper bounds are infinite

--- a/src/pardibaal/DBM.h
+++ b/src/pardibaal/DBM.h
@@ -47,8 +47,8 @@ namespace pardibaal {
     public:
         DBM(dim_t number_of_clocks);
 
-        inline bound_t& at(dim_t i, dim_t j) {return this->_bounds_table.at(i, j);}
         inline bound_t at(dim_t i, dim_t j) const {return this->_bounds_table.at(i, j);}
+        inline void set(dim_t i, dim_t j, bound_t bound) {this->_bounds_table.set(i, j, bound);}
         inline dim_t dimension() const {return this->_bounds_table.number_of_clocks();}
 
         bool is_empty() const;

--- a/src/pardibaal/DBM.h
+++ b/src/pardibaal/DBM.h
@@ -35,10 +35,10 @@ namespace pardibaal {
         relation_t(bool equal, bool subset, bool superset, bool different) :
             _equal(equal), _subset(subset), _superset(superset), _different(different) {}
 
-        static inline relation_t equal() {return relation_t(true, true, true, false);}
-        static inline relation_t subset() {return relation_t(false, true, false, false);}
-        static inline relation_t superset() {return relation_t(false, false, true, false);}
-        static inline relation_t different() {return relation_t(false, false, false, true);}
+        [[nodiscard]] static inline relation_t equal() {return relation_t(true, true, true, false);}
+        [[nodiscard]] static inline relation_t subset() {return relation_t(false, true, false, false);}
+        [[nodiscard]] static inline relation_t superset() {return relation_t(false, false, true, false);}
+        [[nodiscard]] static inline relation_t different() {return relation_t(false, false, false, true);}
     };
 
     class DBM {
@@ -47,23 +47,23 @@ namespace pardibaal {
     public:
         DBM(dim_t number_of_clocks);
 
-        inline bound_t at(dim_t i, dim_t j) const {return this->_bounds_table.at(i, j);}
+        [[nodiscard]] inline bound_t at(dim_t i, dim_t j) const {return this->_bounds_table.at(i, j);}
         inline void set(dim_t i, dim_t j, bound_t bound) {this->_bounds_table.set(i, j, bound);}
-        inline dim_t dimension() const {return this->_bounds_table.number_of_clocks();}
+        [[nodiscard]] inline dim_t dimension() const {return this->_bounds_table.number_of_clocks();}
 
-        bool is_empty() const;
-        bool is_satisfied(dim_t x, dim_t y, bound_t g) const;
-        relation_t relation(const DBM& dbm) const;
+        [[nodiscard]] bool is_empty() const;
+        [[nodiscard]] bool is_satisfied(dim_t x, dim_t y, bound_t g) const;
+        [[nodiscard]] relation_t relation(const DBM& dbm) const;
 
-        inline bool equal(const DBM& dbm) const {return this->relation(dbm)._equal;}
-        inline bool subset(const DBM& dbm) const {return this->relation(dbm)._subset;}
-        inline bool superset(const DBM& dbm) const {return this->relation(dbm)._superset;}
+        [[nodiscard]] inline bool equal(const DBM& dbm) const {return this->relation(dbm)._equal;}
+        [[nodiscard]] inline bool subset(const DBM& dbm) const {return this->relation(dbm)._subset;}
+        [[nodiscard]] inline bool superset(const DBM& dbm) const {return this->relation(dbm)._superset;}
 
         /** Is bounded
          * Checks whether all upper bounds are infinite
          * @return true if the DBM is unbounded (has no upper bound)
          */
-        bool is_unbounded() const;
+        [[nodiscard]] bool is_unbounded() const;
 
         void close();
 

--- a/src/pardibaal/bound_t.cpp
+++ b/src/pardibaal/bound_t.cpp
@@ -40,54 +40,35 @@ namespace pardibaal {
         return b;
     }
 
-    bound_t bound_t::zero() {
-        return non_strict(0);
-    }
+    bound_t bound_t::zero() {return non_strict(0);}
 
-    const bound_t &bound_t::max(const bound_t &a, const bound_t &b) {
-        return a < b ? b : a;
-    }
+    val_t bound_t::get_bound()    const {return this->_n;}
+    bool bound_t::is_strict()     const {return this->_strict;}
+    bool bound_t::is_non_strict() const {return not this->_strict;}
+    bool bound_t::is_inf()        const {return this->_inf;}
 
-    const bound_t bound_t::max(bound_t &&a, bound_t &&b) {
-        return max(a, b);
-    }
+    const bound_t &bound_t::max(const bound_t &a, const bound_t &b) {return a < b ? b : a;}
+    bound_t bound_t::max(bound_t &&a, bound_t &&b) {return max(a, b);}
+    bound_t bound_t::max(const bound_t &a, bound_t &&b) {return max(a, b);}
+    bound_t bound_t::max(bound_t &&a, const bound_t &b) {return max(a, b);}
 
-    const bound_t bound_t::max(const bound_t &a, bound_t &&b) {
-        return max(a, b);
-    }
+    const bound_t &bound_t::min(const bound_t &a, const bound_t &b) {return a <= b ? a : b;}
+    bound_t bound_t::min(bound_t &&a, bound_t &&b) {return bound_t::min(a, b);}
+    bound_t bound_t::min(const bound_t &a, bound_t &&b) {return bound_t::min(a, b);}
+    bound_t bound_t::min(bound_t &&a, const bound_t &b) {return bound_t::min(a, b);}
 
-    const bound_t bound_t::max(bound_t &&a, const bound_t &b) {
-        return max(a, b);
-    }
-
-    const bound_t &bound_t::min(const bound_t &a, const bound_t &b) {
-        return a <= b ? a : b;
-    }
-
-    const bound_t bound_t::min(bound_t &&a, bound_t &&b) {
-        return bound_t::min(a, b);
-    }
-
-    const bound_t bound_t::min(const bound_t &a, bound_t &&b) {
-        return bound_t::min(a, b);
-    }
-
-    const bound_t bound_t::min(bound_t &&a, const bound_t &b) {
-        return bound_t::min(a, b);
-    }
-
-    const bound_t bound_t::operator+(bound_t rhs) const {
+    bound_t bound_t::operator+(bound_t rhs) const {
         if (this->is_inf() || rhs.is_inf())
             return bound_t::inf();
 
         return bound_t(this->get_bound() + rhs.get_bound(), this->is_strict() || rhs.is_strict());
     }
 
-    const bound_t bound_t::operator+(val_t rhs) const {
+    bound_t bound_t::operator+(val_t rhs) const {
         return bound_t(this->get_bound() + rhs, this->is_strict());
     }
 
-    const bound_t bound_t::operator*(val_t rhs) const {
+    bound_t bound_t::operator*(val_t rhs) const {
         return bound_t(this->get_bound() * rhs, this->is_strict());
     }
 
@@ -112,29 +93,18 @@ namespace pardibaal {
         return (this->get_bound() == rhs.get_bound()) && (this->is_strict() == rhs.is_strict());
     }
 
-    bool bound_t::operator!=(bound_t rhs) const {
-        return not (*this == rhs);
-    }
+    bool bound_t::operator!=(bound_t rhs) const {return not (*this == rhs);}
+    bool bound_t::operator>(bound_t rhs)  const {return rhs < *this;}
+    bool bound_t::operator>=(bound_t rhs) const {return not (*this < rhs);}
+    bool bound_t::operator<=(bound_t rhs) const {return not (rhs < *this);}
 
-    bool bound_t::operator>(bound_t rhs) const {
-        return rhs < *this;
-    }
+    bool lt(bound_t lhs, bound_t rhs) {return lhs < rhs;}
+    bool le(bound_t lhs, bound_t rhs) {return lhs <= rhs;}
+    bool gt(bound_t lhs, bound_t rhs) {return lhs > rhs;}
+    bool ge(bound_t lhs, bound_t rhs) {return lhs >= rhs;}
 
-    bool bound_t::operator>=(bound_t rhs) const {
-        return not (*this < rhs);
-    }
-
-    bool bound_t::operator<=(bound_t rhs) const {
-        return not (rhs < *this);
-    }
-
-    const bound_t operator+(val_t val, const bound_t bound) {
-        return bound + val;
-    }
-
-    const bound_t operator*(val_t val, const bound_t bound) {
-        return bound * val;
-    }
+    bound_t operator+(val_t val, bound_t bound) {return bound + val;}
+    bound_t operator*(val_t val, bound_t bound) {return bound * val;}
 
     std::ostream& operator<<(std::ostream& out, const bound_t& bound) {
         if (bound.is_inf()) {

--- a/src/pardibaal/bound_t.cpp
+++ b/src/pardibaal/bound_t.cpp
@@ -77,53 +77,53 @@ namespace pardibaal {
     }
 
     const bound_t bound_t::operator+(bound_t rhs) const {
-        if (this->_inf || rhs._inf)
+        if (this->is_inf() || rhs.is_inf())
             return bound_t::inf();
 
-        return bound_t(this->_n + rhs._n, this->_strict || rhs._strict);
+        return bound_t(this->get_bound() + rhs.get_bound(), this->is_strict() || rhs.is_strict());
     }
 
     const bound_t bound_t::operator+(val_t rhs) const {
-        return bound_t(this->_n + rhs, this->_strict);
+        return bound_t(this->get_bound() + rhs, this->is_strict());
     }
 
     const bound_t bound_t::operator*(val_t rhs) const {
-        return bound_t(this->_n * rhs, this->_strict);
+        return bound_t(this->get_bound() * rhs, this->is_strict());
     }
 
     bool bound_t::operator<=(bound_t rhs) const {
-        if (this->_inf) return rhs._inf;
-        if (rhs._inf) return true;
+        if (this->is_inf()) return rhs.is_inf();
+        if (rhs.is_inf()) return true;
 
-        if (this->_n == rhs._n) {
-            if (rhs._strict)
-                return this->_strict;
+        if (this->get_bound() == rhs.get_bound()) {
+            if (rhs.is_strict())
+                return this->is_strict();
 
             return true;
         }
 
-        return this->_n < rhs._n;
+        return this->get_bound() < rhs.get_bound();
     }
 
     bool bound_t::operator<(bound_t rhs) const {
-        if (this->_inf) return false;
-        if (rhs._inf) return true;
+        if (this->is_inf()) return false;
+        if (rhs.is_inf()) return true;
 
-        if (this->_n == rhs._n) {
-            if (rhs._strict)
+        if (this->get_bound() == rhs.get_bound()) {
+            if (rhs.is_strict())
                 return false;
 
-            return this->_strict;
+            return this->is_strict();
         }
 
-        return this->_n < rhs._n;
+        return this->get_bound() < rhs.get_bound();
     }
 
     bool bound_t::operator==(bound_t rhs) const {
-        if (this->_inf || rhs._inf)
-            return this->_inf && rhs._inf;
+        if (this->is_inf() || rhs.is_inf())
+            return this->is_inf() && rhs.is_inf();
 
-        return (this->_n == rhs._n) && (this->_strict == rhs._strict);
+        return (this->get_bound() == rhs.get_bound()) && (this->is_strict() == rhs.is_strict());
     }
 
     bool bound_t::operator!=(bound_t rhs) const {
@@ -147,11 +147,11 @@ namespace pardibaal {
     }
 
     std::ostream& operator<<(std::ostream& out, const bound_t& bound) {
-        if (bound._inf) {
+        if (bound.is_inf()) {
             out << "INF";
         }
         else {
-            out << (bound._strict ? "<" : "<=") + std::to_string(bound._n);
+            out << (bound.is_strict() ? "<" : "<=") + std::to_string(bound.get_bound());
         }
 
         return out;

--- a/src/pardibaal/bound_t.cpp
+++ b/src/pardibaal/bound_t.cpp
@@ -32,16 +32,16 @@ namespace pardibaal {
 
     bound_t bound_t::non_strict(val_t n) {return bound_t(n, NON_STRICT);}
 
-    bound_t bound_t::zero() {
-        return non_strict(0);
-    }
-
     bound_t bound_t::inf() {
         bound_t b;
         b._inf = true;
         b._strict = true;
 
         return b;
+    }
+
+    bound_t bound_t::zero() {
+        return non_strict(0);
     }
 
     const bound_t &bound_t::max(const bound_t &a, const bound_t &b) {
@@ -91,20 +91,6 @@ namespace pardibaal {
         return bound_t(this->get_bound() * rhs, this->is_strict());
     }
 
-    bool bound_t::operator<=(bound_t rhs) const {
-        if (this->is_inf()) return rhs.is_inf();
-        if (rhs.is_inf()) return true;
-
-        if (this->get_bound() == rhs.get_bound()) {
-            if (rhs.is_strict())
-                return this->is_strict();
-
-            return true;
-        }
-
-        return this->get_bound() < rhs.get_bound();
-    }
-
     bool bound_t::operator<(bound_t rhs) const {
         if (this->is_inf()) return false;
         if (rhs.is_inf()) return true;
@@ -127,7 +113,7 @@ namespace pardibaal {
     }
 
     bool bound_t::operator!=(bound_t rhs) const {
-        return !(*this == rhs);
+        return not (*this == rhs);
     }
 
     bool bound_t::operator>(bound_t rhs) const {
@@ -135,7 +121,11 @@ namespace pardibaal {
     }
 
     bool bound_t::operator>=(bound_t rhs) const {
-        return rhs <= *this;
+        return not (*this < rhs);
+    }
+
+    bool bound_t::operator<=(bound_t rhs) const {
+        return not (rhs < *this);
     }
 
     const bound_t operator+(val_t val, const bound_t bound) {

--- a/src/pardibaal/bound_t.h
+++ b/src/pardibaal/bound_t.h
@@ -48,25 +48,25 @@ namespace pardibaal {
         [[nodiscard]] static bound_t inf();
         [[nodiscard]] static bound_t zero();
 
-        [[nodiscard]] inline val_t get_bound() const {return this->_n;}
-        [[nodiscard]] inline bool is_strict() const {return this->_strict;}
-        [[nodiscard]] inline bool is_non_strict() const {return not this->_strict;}
-        [[nodiscard]] inline bool is_inf() const {return this->_inf;}
+        [[nodiscard]] val_t get_bound() const;
+        [[nodiscard]] bool is_strict() const;
+        [[nodiscard]] bool is_non_strict() const;
+        [[nodiscard]] bool is_inf() const;
 
         [[nodiscard]] static const bound_t& max(const bound_t &a, const bound_t &b);
-        [[nodiscard]] static const bound_t max(bound_t &&a, bound_t &&b);
-        [[nodiscard]] static const bound_t max(const bound_t &a, bound_t &&b);
-        [[nodiscard]] static const bound_t max(bound_t &&a, const bound_t &b);
+        [[nodiscard]] static bound_t max(bound_t &&a, bound_t &&b);
+        [[nodiscard]] static bound_t max(const bound_t &a, bound_t &&b);
+        [[nodiscard]] static bound_t max(bound_t &&a, const bound_t &b);
 
         [[nodiscard]] static const bound_t& min(const bound_t &a, const bound_t &b);
-        [[nodiscard]] static const bound_t min(bound_t &&a, bound_t &&b);
-        [[nodiscard]] static const bound_t min(const bound_t &a, bound_t &&b);
-        [[nodiscard]] static const bound_t min(bound_t &&a, const bound_t &b);
+        [[nodiscard]] static bound_t min(bound_t &&a, bound_t &&b);
+        [[nodiscard]] static bound_t min(const bound_t &a, bound_t &&b);
+        [[nodiscard]] static bound_t min(bound_t &&a, const bound_t &b);
 
-        [[nodiscard]] const bound_t operator+(bound_t rhs) const;
-        [[nodiscard]] const bound_t operator+(val_t rhs) const;
+        [[nodiscard]] bound_t operator+(bound_t rhs) const;
+        [[nodiscard]] bound_t operator+(val_t rhs) const;
 
-        [[nodiscard]] const bound_t operator*(val_t rhs) const;
+        [[nodiscard]] bound_t operator*(val_t rhs) const;
 
         [[nodiscard]] bool operator<(bound_t rhs) const;
         [[nodiscard]] bool operator==(bound_t rhs) const;
@@ -78,14 +78,14 @@ namespace pardibaal {
 
         friend std::ostream& operator<<(std::ostream& out, const bound_t& bound);
 
-        [[nodiscard]] inline static bool lt(bound_t lhs, bound_t rhs) {return lhs < rhs;}
-        [[nodiscard]] inline static bool le(bound_t lhs, bound_t rhs) {return lhs <= rhs;}
-        [[nodiscard]] inline static bool gt(bound_t lhs, bound_t rhs) {return lhs > rhs;}
-        [[nodiscard]] inline static bool ge(bound_t lhs, bound_t rhs) {return lhs >= rhs;}
+        [[nodiscard]] static bool lt(bound_t lhs, bound_t rhs) {return lhs < rhs;}
+        [[nodiscard]] static bool le(bound_t lhs, bound_t rhs) {return lhs <= rhs;}
+        [[nodiscard]] static bool gt(bound_t lhs, bound_t rhs) {return lhs > rhs;}
+        [[nodiscard]] static bool ge(bound_t lhs, bound_t rhs) {return lhs >= rhs;}
     };
 
-    [[nodiscard]] const bound_t operator+(val_t val, const bound_t bound);
-    [[nodiscard]] const bound_t operator*(val_t val, const bound_t bound);
+    [[nodiscard]] bound_t operator+(val_t val, bound_t bound);
+    [[nodiscard]] bound_t operator*(val_t val, bound_t bound);
     std::ostream& operator<<(std::ostream& out, const bound_t& bound);
 }
 

--- a/src/pardibaal/bound_t.h
+++ b/src/pardibaal/bound_t.h
@@ -68,17 +68,13 @@ namespace pardibaal {
 
         const bound_t operator*(val_t rhs) const;
 
-        bool operator<=(bound_t rhs) const;
-
         bool operator<(bound_t rhs) const;
-
         bool operator==(bound_t rhs) const;
 
         bool operator!=(bound_t rhs) const;
-
         bool operator>(bound_t rhs) const;
-
         bool operator>=(bound_t rhs) const;
+        bool operator<=(bound_t rhs) const;
 
         friend std::ostream& operator<<(std::ostream& out, const bound_t& bound);
 

--- a/src/pardibaal/bound_t.h
+++ b/src/pardibaal/bound_t.h
@@ -34,10 +34,11 @@ namespace pardibaal {
     enum strict_t {STRICT, NON_STRICT};
 
     struct bound_t {
+    private:
         val_t _n = 0;
         bool _strict = false,
              _inf = false;
-
+    public:
         bound_t(){};
         bound_t(val_t n, strict_t strictness);
         bound_t(val_t n, bool strict);
@@ -47,6 +48,10 @@ namespace pardibaal {
         static bound_t inf();
         static bound_t zero();
 
+        inline val_t get_bound() const {return this->_n;}
+        inline bool is_strict() const {return this->_strict;}
+        inline bool is_non_strict() const {return not this->_strict;}
+        inline bool is_inf() const {return this->_inf;}
 
         static const bound_t& max(const bound_t &a, const bound_t &b);
         static const bound_t max(bound_t &&a, bound_t &&b);

--- a/src/pardibaal/bound_t.h
+++ b/src/pardibaal/bound_t.h
@@ -43,49 +43,49 @@ namespace pardibaal {
         bound_t(val_t n, strict_t strictness);
         bound_t(val_t n, bool strict);
 
-        static bound_t strict(val_t n);
-        static bound_t non_strict(val_t n);
-        static bound_t inf();
-        static bound_t zero();
+        [[nodiscard]] static bound_t strict(val_t n);
+        [[nodiscard]] static bound_t non_strict(val_t n);
+        [[nodiscard]] static bound_t inf();
+        [[nodiscard]] static bound_t zero();
 
-        inline val_t get_bound() const {return this->_n;}
-        inline bool is_strict() const {return this->_strict;}
-        inline bool is_non_strict() const {return not this->_strict;}
-        inline bool is_inf() const {return this->_inf;}
+        [[nodiscard]] inline val_t get_bound() const {return this->_n;}
+        [[nodiscard]] inline bool is_strict() const {return this->_strict;}
+        [[nodiscard]] inline bool is_non_strict() const {return not this->_strict;}
+        [[nodiscard]] inline bool is_inf() const {return this->_inf;}
 
-        static const bound_t& max(const bound_t &a, const bound_t &b);
-        static const bound_t max(bound_t &&a, bound_t &&b);
-        static const bound_t max(const bound_t &a, bound_t &&b);
-        static const bound_t max(bound_t &&a, const bound_t &b);
+        [[nodiscard]] static const bound_t& max(const bound_t &a, const bound_t &b);
+        [[nodiscard]] static const bound_t max(bound_t &&a, bound_t &&b);
+        [[nodiscard]] static const bound_t max(const bound_t &a, bound_t &&b);
+        [[nodiscard]] static const bound_t max(bound_t &&a, const bound_t &b);
 
-        static const bound_t& min(const bound_t &a, const bound_t &b);
-        static const bound_t min(bound_t &&a, bound_t &&b);
-        static const bound_t min(const bound_t &a, bound_t &&b);
-        static const bound_t min(bound_t &&a, const bound_t &b);
+        [[nodiscard]] static const bound_t& min(const bound_t &a, const bound_t &b);
+        [[nodiscard]] static const bound_t min(bound_t &&a, bound_t &&b);
+        [[nodiscard]] static const bound_t min(const bound_t &a, bound_t &&b);
+        [[nodiscard]] static const bound_t min(bound_t &&a, const bound_t &b);
 
-        const bound_t operator+(bound_t rhs) const;
-        const bound_t operator+(val_t rhs) const;
+        [[nodiscard]] const bound_t operator+(bound_t rhs) const;
+        [[nodiscard]] const bound_t operator+(val_t rhs) const;
 
-        const bound_t operator*(val_t rhs) const;
+        [[nodiscard]] const bound_t operator*(val_t rhs) const;
 
-        bool operator<(bound_t rhs) const;
-        bool operator==(bound_t rhs) const;
+        [[nodiscard]] bool operator<(bound_t rhs) const;
+        [[nodiscard]] bool operator==(bound_t rhs) const;
 
-        bool operator!=(bound_t rhs) const;
-        bool operator>(bound_t rhs) const;
-        bool operator>=(bound_t rhs) const;
-        bool operator<=(bound_t rhs) const;
+        [[nodiscard]] bool operator!=(bound_t rhs) const;
+        [[nodiscard]] bool operator>(bound_t rhs) const;
+        [[nodiscard]] bool operator>=(bound_t rhs) const;
+        [[nodiscard]] bool operator<=(bound_t rhs) const;
 
         friend std::ostream& operator<<(std::ostream& out, const bound_t& bound);
 
-        inline static bool lt(bound_t lhs, bound_t rhs) {return lhs < rhs;}
-        inline static bool le(bound_t lhs, bound_t rhs) {return lhs <= rhs;}
-        inline static bool gt(bound_t lhs, bound_t rhs) {return lhs > rhs;}
-        inline static bool ge(bound_t lhs, bound_t rhs) {return lhs >= rhs;}
+        [[nodiscard]] inline static bool lt(bound_t lhs, bound_t rhs) {return lhs < rhs;}
+        [[nodiscard]] inline static bool le(bound_t lhs, bound_t rhs) {return lhs <= rhs;}
+        [[nodiscard]] inline static bool gt(bound_t lhs, bound_t rhs) {return lhs > rhs;}
+        [[nodiscard]] inline static bool ge(bound_t lhs, bound_t rhs) {return lhs >= rhs;}
     };
 
-    const bound_t operator+(val_t val, const bound_t bound);
-    const bound_t operator*(val_t val, const bound_t bound);
+    [[nodiscard]] const bound_t operator+(val_t val, const bound_t bound);
+    [[nodiscard]] const bound_t operator*(val_t val, const bound_t bound);
     std::ostream& operator<<(std::ostream& out, const bound_t& bound);
 }
 

--- a/src/pardibaal/bounds_table_t.cpp
+++ b/src/pardibaal/bounds_table_t.cpp
@@ -29,6 +29,8 @@ namespace pardibaal {
         _bounds = std::vector<bound_t>(number_of_clocks * number_of_clocks);
     }
 
+    dim_t bounds_table_t::number_of_clocks() const {return this->_number_of_clocks;}
+
     bound_t bounds_table_t::at(dim_t i, dim_t j) const {
 #ifndef NEXCEPTIONS
         if (i >= _number_of_clocks || j >= _number_of_clocks)

--- a/src/pardibaal/bounds_table_t.cpp
+++ b/src/pardibaal/bounds_table_t.cpp
@@ -29,16 +29,6 @@ namespace pardibaal {
         _bounds = std::vector<bound_t>(number_of_clocks * number_of_clocks);
     }
 
-    bound_t &bounds_table_t::at(dim_t i, dim_t j) {
-#ifndef NEXCEPTIONS
-        if (i >= _number_of_clocks || j >= _number_of_clocks)
-            throw base_error("ERROR: Out of bounds access on coordinate: ", i, ", ", j, " with dimensions: ",
-                             _number_of_clocks);
-#endif
-
-        return _bounds[i * _number_of_clocks + j];
-    }
-
     bound_t bounds_table_t::at(dim_t i, dim_t j) const {
 #ifndef NEXCEPTIONS
         if (i >= _number_of_clocks || j >= _number_of_clocks)

--- a/src/pardibaal/bounds_table_t.cpp
+++ b/src/pardibaal/bounds_table_t.cpp
@@ -49,6 +49,15 @@ namespace pardibaal {
         return _bounds[i * _number_of_clocks + j];
     }
 
+    void bounds_table_t::set(dim_t i, dim_t j, bound_t bound) {
+#ifndef NEXCEPTIONS
+        if (i >= _number_of_clocks || j >= _number_of_clocks)
+            throw base_error("ERROR: Out of bounds access on coordinate: ", i, ", ", j, " with dimensions: ",
+                             _number_of_clocks);
+#endif
+        this->_bounds[i * _number_of_clocks + j] = bound;
+    }
+
     std::ostream& operator<<(std::ostream& out, const bounds_table_t& table) {
         for (dim_t i = 0; i < table._number_of_clocks; ++i) {
             for (dim_t j = 0; j < table._number_of_clocks; ++j) {

--- a/src/pardibaal/bounds_table_t.h
+++ b/src/pardibaal/bounds_table_t.h
@@ -36,9 +36,9 @@ namespace pardibaal {
          * same as the dimension of the "matrix"
          * @return number of clocks including the zero clock
          */
-        inline dim_t number_of_clocks() const {return this->_number_of_clocks;}
+        [[nodiscard]] inline dim_t number_of_clocks() const {return this->_number_of_clocks;}
 
-        bound_t at(dim_t i, dim_t j) const;
+        [[nodiscard]] bound_t at(dim_t i, dim_t j) const;
         void set(dim_t i, dim_t j, bound_t bound);
 
         friend std::ostream& operator<<(std::ostream& out, const bounds_table_t& table);

--- a/src/pardibaal/bounds_table_t.h
+++ b/src/pardibaal/bounds_table_t.h
@@ -36,7 +36,7 @@ namespace pardibaal {
          * same as the dimension of the "matrix"
          * @return number of clocks including the zero clock
          */
-        [[nodiscard]] inline dim_t number_of_clocks() const {return this->_number_of_clocks;}
+        [[nodiscard]] dim_t number_of_clocks() const;
 
         [[nodiscard]] bound_t at(dim_t i, dim_t j) const;
         void set(dim_t i, dim_t j, bound_t bound);

--- a/src/pardibaal/bounds_table_t.h
+++ b/src/pardibaal/bounds_table_t.h
@@ -38,8 +38,8 @@ namespace pardibaal {
          */
         inline dim_t number_of_clocks() const {return this->_number_of_clocks;}
 
-        bound_t &at(dim_t i, dim_t j);
-        [[nodiscard]] bound_t at(dim_t i, dim_t j) const;
+        bound_t at(dim_t i, dim_t j) const;
+        void set(dim_t i, dim_t j, bound_t bound);
 
         friend std::ostream& operator<<(std::ostream& out, const bounds_table_t& table);
 

--- a/test/DBM_test.cpp
+++ b/test/DBM_test.cpp
@@ -214,10 +214,10 @@ BOOST_AUTO_TEST_CASE(trace_test_1) {
 
 BOOST_AUTO_TEST_CASE(remove_clock_test_1) {
     DBM D(4);
-    D.at(1, 0) = bound_t::inf();
-    D.at(3, 0) = bound_t::inf();
-    D.at(1, 2) = bound_t::inf();
-    D.at(3, 2) = bound_t::inf();
+    D.set(1, 0, bound_t::inf());
+    D.set(3, 0, bound_t::inf());
+    D.set(1, 2, bound_t::inf());
+    D.set(3, 2, bound_t::inf());
 
     D.remove_clock(2);
 
@@ -288,10 +288,10 @@ BOOST_AUTO_TEST_CASE(swap_clocks_test_2) {
 
 BOOST_AUTO_TEST_CASE(add_clock_test_1) {
     DBM D(4);
-    D.at(1, 0) = bound_t::inf();
-    D.at(3, 0) = bound_t::inf();
-    D.at(1, 2) = bound_t::inf();
-    D.at(3, 2) = bound_t::inf();
+    D.set(1, 0, bound_t::inf());
+    D.set(3, 0, bound_t::inf());
+    D.set(1, 2, bound_t::inf());
+    D.set(3, 2, bound_t::inf());
     std::cout << D << std::endl;
     D.add_clock_at(3);
     std::cout << D << std::endl;
@@ -445,13 +445,13 @@ BOOST_AUTO_TEST_CASE(diagonal_extrapolation_test_2) {
 //  <=1     <=0     <=1     <=0
     std::vector<val_t> ceiling = {0, 1, -1073741823, 3};
 
-    D.at(1, 0) = bound_t::non_strict(1);
-    D.at(1, 2) = bound_t::non_strict(1);
-    D.at(3, 0) = bound_t::non_strict(1);
-    D.at(3, 2) = bound_t::non_strict(1);
-    D.at(2, 0) = bound_t::inf();
-    D.at(2, 1) = bound_t::inf();
-    D.at(2, 3) = bound_t::inf();
+    D.set(1, 0, bound_t::non_strict(1));
+    D.set(1, 2, bound_t::non_strict(1));
+    D.set(3, 0, bound_t::non_strict(1));
+    D.set(3, 2, bound_t::non_strict(1));
+    D.set(2, 0, bound_t::inf());
+    D.set(2, 1, bound_t::inf());
+    D.set(2, 3, bound_t::inf());
 
     D.extrapolate_diagonal(ceiling);
 
@@ -477,21 +477,21 @@ BOOST_AUTO_TEST_CASE(diagonal_extrapolation_test_3) {
     DBM D(5);
     std::vector<val_t> ceiling = {0, 3, -1073741823, 3, 3};
 
-    D.at(0, 1) = bound_t::non_strict(-6);
-    D.at(3, 1) = bound_t::non_strict(-6);
-    D.at(4, 1) = bound_t::non_strict(-6);
+    D.set(0, 1, bound_t::non_strict(-6));
+    D.set(3, 1, bound_t::non_strict(-6));
+    D.set(4, 1, bound_t::non_strict(-6));
 
-    D.at(1, 0) = bound_t::inf();
-    D.at(2, 0) = bound_t::inf();
-    D.at(3, 0) = bound_t::inf();
-    D.at(4, 0) = bound_t::inf();
+    D.set(1, 0, bound_t::inf());
+    D.set(2, 0, bound_t::inf());
+    D.set(3, 0, bound_t::inf());
+    D.set(4, 0, bound_t::inf());
 
-    D.at(2, 1) = bound_t::inf();
-    D.at(1, 2) = bound_t::inf();
-    D.at(1, 3) = bound_t::inf();
-    D.at(2, 3) = bound_t::inf();
-    D.at(1, 4) = bound_t::inf();
-    D.at(2, 4) = bound_t::inf();
+    D.set(2, 1, bound_t::inf());
+    D.set(1, 2, bound_t::inf());
+    D.set(1, 3, bound_t::inf());
+    D.set(2, 3, bound_t::inf());
+    D.set(1, 4, bound_t::inf());
+    D.set(2, 4, bound_t::inf());
 
     D.extrapolate_diagonal(ceiling);
 

--- a/test/DBM_test.cpp
+++ b/test/DBM_test.cpp
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(swap_clocks_test_1) {
     for (dim_t i = 0; i < size; ++i)
         for (dim_t j = 0; j < size; ++j) {
             if (i == j) continue;
-            D.at(i, j) = bound_t::non_strict(j + (i * size));
+            D.set(i, j, bound_t::non_strict(j + (i * size)));
         }
 
     D.swap_clocks(a, b);

--- a/test/bound_test.cpp
+++ b/test/bound_test.cpp
@@ -28,14 +28,14 @@ using namespace pardibaal;
 
 BOOST_AUTO_TEST_CASE(inf_test_1) {
     bound_t b = bound_t::inf();
-    BOOST_CHECK(b._inf);
+    BOOST_CHECK(b.is_inf());
 }
 
 BOOST_AUTO_TEST_CASE(zero_test_1) {
     bound_t b = bound_t::zero();
-    BOOST_CHECK(!b._inf);
-    BOOST_CHECK(!b._strict);
-    BOOST_CHECK(b._n == 0);
+    BOOST_CHECK(not b.is_inf());
+    BOOST_CHECK(b.is_non_strict());
+    BOOST_CHECK(b.get_bound() == 0);
 }
 
 BOOST_AUTO_TEST_CASE(equal_test_1) {


### PR DESCRIPTION
Add setter method for DBM entries instead of `dbm.at(i, j) = bound` it is `dbm.set(i, j, bound)`. It will be easier to replace implementations of the bounds_table_t structure in the future.

Reorganise bound_t methods so the fields are accessed through methods. Makes changes to the structure easier.

Remove the use of inline and add [[nodiscard]] where possible.