### PR TITLE
Add intersection check to fed and dbm

### DIFF
--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -112,6 +112,35 @@ namespace pardibaal {
     bool DBM::superset(const DBM& dbm) const        {return this->relation(dbm)._superset;}
     bool DBM::superset(const Federation &fed) const {return this->relation(fed)._superset;}
 
+    bool DBM::intersects(const DBM &dbm) const {
+#ifndef NEXCEPTIONS
+        if (dbm.dimension() != dimension())
+            throw(base_error("ERROR: Cannot measure intersection of two dbms with different dimensions. ",
+                             "Got dimensions ", dbm.dimension(), " and ", dimension()));
+#endif
+
+        for (dim_t i = 0; i < dimension(); ++i) {
+            for (dim_t j = 0; j < dimension(); ++j) {
+                bound_t b1 = this->at(i, j);
+                bound_t b2 = dbm.at(j, i);
+
+                // For opposite diagonal bounds: if they are both + or -, then they overlap
+                // Upper bounds can be inf; if upper bound is inf, then it overlaps with any opposite lower bound
+                if ((b1 > bound_t::zero() && b2 > bound_t::zero()) ||
+                    (b1 < bound_t::zero() && b2 < bound_t::zero()) ||
+                    (b1.is_inf() || b2.is_inf()))
+                    continue;
+                else if (not (b1 * -1 <= b2)) return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool DBM::intersects(const Federation& fed) const {
+        return fed.intersects(*this);
+    }
+
     bool DBM::is_unbounded() const {
         for (dim_t i = 1; i < dimension(); ++i)
             if (not this->at(i, 0).is_inf())

--- a/src/pardibaal/DBM.h
+++ b/src/pardibaal/DBM.h
@@ -73,13 +73,13 @@ namespace pardibaal {
         [[nodiscard]] bool superset(const Federation& fed) const;
 
         /**
-         * Checks if two DBMs intersect ie. if the union is non-empty
+         * Checks if two DBMs intersect ie. if the intersection is non-empty
          * @return true if this intersects with dbm
          */
         [[nodiscard]] bool intersects(const DBM& dbm) const;
 
         /**
-         * Checks if a DBM intersect with a federation ie. if the union is non-empty
+         * Checks if a DBM intersect with a federation ie. if the intersection is non-empty
          * @return true if this intersects with fed
          */
         [[nodiscard]] bool intersects(const Federation& fed) const;

--- a/src/pardibaal/DBM.h
+++ b/src/pardibaal/DBM.h
@@ -72,6 +72,18 @@ namespace pardibaal {
         [[nodiscard]] bool superset(const DBM& dbm) const;
         [[nodiscard]] bool superset(const Federation& fed) const;
 
+        /**
+         * Checks if two DBMs intersect ie. if the union is non-empty
+         * @return true if this intersects with dbm
+         */
+        [[nodiscard]] bool intersects(const DBM& dbm) const;
+
+        /**
+         * Checks if a DBM intersect with a federation ie. if the union is non-empty
+         * @return true if this intersects with fed
+         */
+        [[nodiscard]] bool intersects(const Federation& fed) const;
+
         /** Is bounded
          * Checks whether all upper bounds are infinite
          * @return true if the DBM is unbounded (has no upper bound)

--- a/src/pardibaal/Federation.cpp
+++ b/src/pardibaal/Federation.cpp
@@ -199,6 +199,14 @@ namespace pardibaal {
         return this->relation(fed)._superset;
     }
 
+    bool Federation::intersects(const DBM &dbm) const {
+        return std::any_of(this->begin(), this->end(), [&dbm](const DBM& z){return z.intersects(dbm);});
+    }
+
+    bool Federation::intersects(const Federation& fed) const {
+        return std::any_of(fed.begin(), fed.end(), [this](const DBM& dbm){return this->intersects(dbm);});
+    }
+
     bool Federation::is_unbounded() const {
         bool rtn = true;
         for (const DBM& dbm : zones)

--- a/src/pardibaal/Federation.h
+++ b/src/pardibaal/Federation.h
@@ -185,7 +185,16 @@ namespace pardibaal {
          */
         [[nodiscard]] bool superset(const Federation& fed) const;
 
+        /**
+         * Checks if a federation intersect with a federation ie. if the intersection is non-empty
+         * @return true if this intersects with dbm
+         */
         [[nodiscard]] bool intersects(const DBM& dbm) const;
+
+        /**
+         * Checks if a federation intersect with a DBM ie. if the intersection is non-empty
+         * @return true if this intersects with fed
+         */
         [[nodiscard]] bool intersects(const Federation& fed) const;
 
         /**

--- a/src/pardibaal/Federation.h
+++ b/src/pardibaal/Federation.h
@@ -185,6 +185,9 @@ namespace pardibaal {
          */
         [[nodiscard]] bool superset(const Federation& fed) const;
 
+        [[nodiscard]] bool intersects(const DBM& dbm) const;
+        [[nodiscard]] bool intersects(const Federation& fed) const;
+
         /**
          * Checks if the any of the zones have upper bounds
          * @return true if one of the zones in the federation is unbounded

--- a/test/DBM_test.cpp
+++ b/test/DBM_test.cpp
@@ -804,6 +804,30 @@ BOOST_AUTO_TEST_CASE(relation_test_4) {
     BOOST_CHECK(a.equal(b));
 }
 
+BOOST_AUTO_TEST_CASE(intersects_test_1) {
+    DBM dbm1(3);
+    DBM dbm2(3);
+
+    BOOST_CHECK(dbm1.intersects(dbm2));
+    BOOST_CHECK(dbm2.intersects(dbm1));
+    dbm1.future();
+
+    BOOST_CHECK(dbm1.intersects(dbm2));
+    BOOST_CHECK(dbm2.intersects(dbm1));
+
+    dbm1.free(1);
+    dbm1.free(2);
+
+    BOOST_CHECK(dbm1.intersects(dbm2));
+    BOOST_CHECK(dbm2.intersects(dbm1));
+
+    dbm1.restrict(0, 1, bound_t::strict(-2));
+    dbm1.restrict(0, 2, bound_t::strict(-3));
+
+    BOOST_CHECK(not dbm1.intersects(dbm2));
+    BOOST_CHECK(not dbm2.intersects(dbm1));
+}
+
 BOOST_AUTO_TEST_CASE(zero_test_1) {
     dim_t dimension = 10;
     DBM dbm(dimension);

--- a/test/Federation_test.cpp
+++ b/test/Federation_test.cpp
@@ -202,6 +202,81 @@ BOOST_AUTO_TEST_CASE(relation_test_3){
     BOOST_CHECK(fed2.subset(fed1));
 }
 
+BOOST_AUTO_TEST_CASE(intersects_test_1) {
+    auto fed = Federation::zero(3);
+    auto dbm = DBM::zero(3);
+
+    BOOST_CHECK(fed.intersects(dbm));
+    BOOST_CHECK(dbm.intersects(fed));
+
+    fed.future();
+
+    BOOST_CHECK(fed.intersects(dbm));
+    BOOST_CHECK(dbm.intersects(fed));
+
+    auto dbm2 = DBM::unconstrained(3);
+    dbm2.restrict(0, 1, bound_t::strict(-2));
+    dbm2.restrict(0, 2, bound_t::strict(-3));
+    fed.add(dbm2);
+
+    BOOST_CHECK(fed.size() == 2);
+    BOOST_CHECK(fed.intersects(dbm));
+    BOOST_CHECK(dbm.intersects(fed));
+
+    dbm.future();
+
+    BOOST_CHECK(fed.intersects(dbm));
+    BOOST_CHECK(dbm.intersects(fed));
+
+    dbm.shift(1, 1);
+
+    BOOST_CHECK(fed.intersects(dbm));
+    BOOST_CHECK(dbm.intersects(fed));
+
+    dbm.restrict(1, 0, bound_t::strict(2));
+
+    BOOST_CHECK(not fed.intersects(dbm));
+    BOOST_CHECK(not dbm.intersects(fed));
+}
+
+BOOST_AUTO_TEST_CASE(intersects_test_2) {
+    auto fed1 = Federation::zero(3);
+    auto fed2 = Federation::zero(3);
+
+    BOOST_CHECK(fed1.intersects(fed2));
+    BOOST_CHECK(fed2.intersects(fed1));
+
+    fed1.future();
+
+    BOOST_CHECK(fed1.intersects(fed2));
+    BOOST_CHECK(fed2.intersects(fed1));
+
+    auto dbm = DBM::unconstrained(3);
+    dbm.restrict(0, 1, bound_t::strict(-2));
+    dbm.restrict(0, 2, bound_t::strict(-3));
+    fed1.add(dbm);
+
+    BOOST_CHECK(fed1.size() == 2);
+    BOOST_CHECK(fed1.intersects(fed2));
+    BOOST_CHECK(fed2.intersects(fed1));
+
+    fed2.future();
+
+    BOOST_CHECK(fed1.intersects(fed2));
+    BOOST_CHECK(fed2.intersects(fed1));
+
+    fed2.shift(1, 1);
+
+    BOOST_CHECK(fed1.intersects(fed2));
+    BOOST_CHECK(fed2.intersects(fed1));
+    BOOST_CHECK(fed1.intersects(fed2.at(0)));
+
+    fed2.restrict(1, 0, bound_t::strict(2));
+
+    BOOST_CHECK(not fed1.intersects(fed2));
+    BOOST_CHECK(not fed2.intersects(fed1));
+}
+
 BOOST_AUTO_TEST_CASE(is_unbounded_test_1){
     Federation fed(3);
     DBM dbm(3);


### PR DESCRIPTION
Check if dbms and federations intersects with each other, ie. if the intersection is non-empty.