### PR TITLE
Exact relation

### DIFF
--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -117,7 +117,7 @@ namespace pardibaal {
         return relation_t::different();
     }
 
-    template<bool is_exact>
+    template<bool is_exact = true>
     relation_t DBM::relation(const Federation& fed) const {
         auto r = fed.relation<is_exact>(*this);
 

--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -122,12 +122,25 @@ namespace pardibaal {
         return relation_t::different();
     }
 
-    bool DBM::equal(const DBM& dbm) const           {return this->relation(dbm)._equal;}
-    bool DBM::equal(const Federation &fed) const    {return this->relation(fed)._equal;}
-    bool DBM::subset(const DBM& dbm) const          {return this->relation(dbm)._subset;}
-    bool DBM::subset(const Federation &fed) const   {return this->relation(fed)._subset;}
-    bool DBM::superset(const DBM& dbm) const        {return this->relation(dbm)._superset;}
-    bool DBM::superset(const Federation &fed) const {return this->relation(fed)._superset;}
+    relation_t DBM::exact_relation(const Federation& fed) const {
+        auto r = fed.exact_relation(*this);
+
+        if (r._equal) return relation_t::equal();
+        if (r._superset) return relation_t::subset();
+        if (r._subset) return relation_t::superset();
+
+        return relation_t::different();
+    }
+
+    bool DBM::equal(const DBM& dbm) const                    {return this->relation(dbm)._equal;}
+    bool DBM::equal(const Federation &fed) const             {return this->relation(fed)._equal;}
+    bool DBM::exact_equal(const Federation& fed) const       {return this->exact_relation(fed)._equal;}
+    bool DBM::subset(const DBM& dbm) const                   {return this->relation(dbm)._subset;}
+    bool DBM::subset(const Federation &fed) const            {return this->relation(fed)._subset;}
+    bool DBM::exact_subset(const Federation &fed) const      {return this->exact_relation(fed)._subset;}
+    bool DBM::superset(const DBM& dbm) const                 {return this->relation(dbm)._superset;}
+    bool DBM::superset(const Federation &fed) const          {return this->relation(fed)._superset;}
+    bool DBM::exact_superset(const Federation &fed) const    {return this->exact_relation(fed)._superset;}
 
     bool DBM::intersects(const DBM &dbm) const {
 #ifndef NEXCEPTIONS

--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -112,8 +112,9 @@ namespace pardibaal {
         return relation_t::different();
     }
 
-    relation_t DBM::relation(const Federation &fed) const {
-        auto r = fed.relation(*this);
+    template<bool is_exact>
+    relation_t DBM::relation(const Federation& fed) const {
+        auto r = fed.relation<is_exact>(*this);
 
         if (r._equal) return relation_t::equal();
         if (r._superset) return relation_t::subset();
@@ -122,25 +123,40 @@ namespace pardibaal {
         return relation_t::different();
     }
 
-    relation_t DBM::exact_relation(const Federation& fed) const {
-        auto r = fed.exact_relation(*this);
+    bool DBM::equal(const DBM& dbm)            const {return this->relation(dbm)._equal;}
+    
+    template<bool is_exact = true>
+    bool DBM::equal(const Federation &fed)     const {return this->relation<is_exact>(fed)._equal;}
+    
+    bool DBM::subset(const DBM& dbm)           const {return this->relation(dbm)._subset;}
+    
+    template<bool is_exact = true>
+    bool DBM::subset(const Federation &fed)    const {return this->relation<is_exact>(fed)._subset;}
+    
+    bool DBM::superset(const DBM& dbm)         const {return this->relation(dbm)._superset;}
+    
+    template<bool is_exact = true>
+    bool DBM::superset(const Federation &fed)  const {return this->relation<is_exact>(fed)._superset;}
 
-        if (r._equal) return relation_t::equal();
-        if (r._superset) return relation_t::subset();
-        if (r._subset) return relation_t::superset();
+    bool DBM::different(const DBM& dbm)        const {return this->relation(dbm)._different;}
+    
+    template<bool is_exact = true>
+    bool DBM::different(const Federation &fed) const {return this->relation<is_exact>(fed)._different;}
 
-        return relation_t::different();
-    }
+    template relation_t DBM::relation<true>(const Federation& fed) const;
+    template relation_t DBM::relation<false>(const Federation& fed) const;
 
-    bool DBM::equal(const DBM& dbm) const                    {return this->relation(dbm)._equal;}
-    bool DBM::equal(const Federation &fed) const             {return this->relation(fed)._equal;}
-    bool DBM::exact_equal(const Federation& fed) const       {return this->exact_relation(fed)._equal;}
-    bool DBM::subset(const DBM& dbm) const                   {return this->relation(dbm)._subset;}
-    bool DBM::subset(const Federation &fed) const            {return this->relation(fed)._subset;}
-    bool DBM::exact_subset(const Federation &fed) const      {return this->exact_relation(fed)._subset;}
-    bool DBM::superset(const DBM& dbm) const                 {return this->relation(dbm)._superset;}
-    bool DBM::superset(const Federation &fed) const          {return this->relation(fed)._superset;}
-    bool DBM::exact_superset(const Federation &fed) const    {return this->exact_relation(fed)._superset;}
+    template bool DBM::equal<true>(const Federation& fed) const;
+    template bool DBM::equal<false>(const Federation& fed) const;
+    
+    template bool DBM::subset<true>(const Federation& fed) const;
+    template bool DBM::subset<false>(const Federation& fed) const;
+    
+    template bool DBM::superset<true>(const Federation& fed) const;
+    template bool DBM::superset<false>(const Federation& fed) const;
+
+    template bool DBM::different<true>(const Federation& fed) const;
+    template bool DBM::different<false>(const Federation& fed) const;
 
     bool DBM::intersects(const DBM &dbm) const {
 #ifndef NEXCEPTIONS

--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -117,7 +117,7 @@ namespace pardibaal {
         return relation_t::different();
     }
 
-    template<bool is_exact = true>
+    template<bool is_exact>
     relation_t DBM::relation(const Federation& fed) const {
         auto r = fed.relation<is_exact>(*this);
 
@@ -130,22 +130,22 @@ namespace pardibaal {
 
     bool DBM::is_equal(const DBM& dbm)            const {return this->relation(dbm).is_equal();}
     
-    template<bool is_exact = true>
+    template<bool is_exact>
     bool DBM::is_equal(const Federation &fed)     const {return this->relation<is_exact>(fed).is_equal();}
     
     bool DBM::is_subset(const DBM& dbm)           const {return this->relation(dbm).is_subset();}
     
-    template<bool is_exact = true>
+    template<bool is_exact>
     bool DBM::is_subset(const Federation &fed)    const {return this->relation<is_exact>(fed).is_subset();}
     
     bool DBM::is_superset(const DBM& dbm)         const {return this->relation(dbm).is_superset();}
     
-    template<bool is_exact = true>
+    template<bool is_exact>
     bool DBM::is_superset(const Federation &fed)  const {return this->relation<is_exact>(fed).is_superset();}
 
     bool DBM::is_different(const DBM& dbm)        const {return this->relation(dbm).is_different();}
     
-    template<bool is_exact = true>
+    template<bool is_exact>
     bool DBM::is_different(const Federation &fed) const {return this->relation<is_exact>(fed).is_different();}
 
     template relation_t DBM::relation<true>(const Federation& fed) const;

--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -36,6 +36,11 @@ namespace pardibaal {
     relation_t relation_t::superset() {return relation_t(false, false, true, false);}
     relation_t relation_t::different() {return relation_t(false, false, false, true);}
 
+    bool relation_t::is_equal() const {return _is_equal;}
+    bool relation_t::is_subset() const {return _is_subset;}
+    bool relation_t::is_superset() const {return _is_superset;}
+    bool relation_t::is_different() const {return _is_different;}
+
     DBM::DBM(dim_t number_of_clocks) : _bounds_table(number_of_clocks) {}
 
     DBM DBM::zero(dim_t dimension) {return DBM(dimension);}
@@ -116,47 +121,47 @@ namespace pardibaal {
     relation_t DBM::relation(const Federation& fed) const {
         auto r = fed.relation<is_exact>(*this);
 
-        if (r._equal) return relation_t::equal();
-        if (r._superset) return relation_t::subset();
-        if (r._subset) return relation_t::superset();
+        if (r.is_equal()) return relation_t::equal();
+        if (r.is_superset()) return relation_t::subset();
+        if (r.is_subset()) return relation_t::superset();
 
         return relation_t::different();
     }
 
-    bool DBM::equal(const DBM& dbm)            const {return this->relation(dbm)._equal;}
+    bool DBM::is_equal(const DBM& dbm)            const {return this->relation(dbm).is_equal();}
     
     template<bool is_exact = true>
-    bool DBM::equal(const Federation &fed)     const {return this->relation<is_exact>(fed)._equal;}
+    bool DBM::is_equal(const Federation &fed)     const {return this->relation<is_exact>(fed).is_equal();}
     
-    bool DBM::subset(const DBM& dbm)           const {return this->relation(dbm)._subset;}
-    
-    template<bool is_exact = true>
-    bool DBM::subset(const Federation &fed)    const {return this->relation<is_exact>(fed)._subset;}
-    
-    bool DBM::superset(const DBM& dbm)         const {return this->relation(dbm)._superset;}
+    bool DBM::is_subset(const DBM& dbm)           const {return this->relation(dbm).is_subset();}
     
     template<bool is_exact = true>
-    bool DBM::superset(const Federation &fed)  const {return this->relation<is_exact>(fed)._superset;}
+    bool DBM::is_subset(const Federation &fed)    const {return this->relation<is_exact>(fed).is_subset();}
+    
+    bool DBM::is_superset(const DBM& dbm)         const {return this->relation(dbm).is_superset();}
+    
+    template<bool is_exact = true>
+    bool DBM::is_superset(const Federation &fed)  const {return this->relation<is_exact>(fed).is_superset();}
 
-    bool DBM::different(const DBM& dbm)        const {return this->relation(dbm)._different;}
+    bool DBM::is_different(const DBM& dbm)        const {return this->relation(dbm).is_different();}
     
     template<bool is_exact = true>
-    bool DBM::different(const Federation &fed) const {return this->relation<is_exact>(fed)._different;}
+    bool DBM::is_different(const Federation &fed) const {return this->relation<is_exact>(fed).is_different();}
 
     template relation_t DBM::relation<true>(const Federation& fed) const;
     template relation_t DBM::relation<false>(const Federation& fed) const;
 
-    template bool DBM::equal<true>(const Federation& fed) const;
-    template bool DBM::equal<false>(const Federation& fed) const;
+    template bool DBM::is_equal<true>(const Federation& fed) const;
+    template bool DBM::is_equal<false>(const Federation& fed) const;
     
-    template bool DBM::subset<true>(const Federation& fed) const;
-    template bool DBM::subset<false>(const Federation& fed) const;
+    template bool DBM::is_subset<true>(const Federation& fed) const;
+    template bool DBM::is_subset<false>(const Federation& fed) const;
     
-    template bool DBM::superset<true>(const Federation& fed) const;
-    template bool DBM::superset<false>(const Federation& fed) const;
+    template bool DBM::is_superset<true>(const Federation& fed) const;
+    template bool DBM::is_superset<false>(const Federation& fed) const;
 
-    template bool DBM::different<true>(const Federation& fed) const;
-    template bool DBM::different<false>(const Federation& fed) const;
+    template bool DBM::is_different<true>(const Federation& fed) const;
+    template bool DBM::is_different<false>(const Federation& fed) const;
 
     bool DBM::intersects(const DBM &dbm) const {
 #ifndef NEXCEPTIONS

--- a/src/pardibaal/DBM.h
+++ b/src/pardibaal/DBM.h
@@ -38,14 +38,22 @@ namespace pardibaal {
      * different means that they are neither equal or a sub/superset of each other, or the dimensions are different.
      */
     struct relation_t {
-        bool _equal, _subset, _superset, _different;
+    private:
+        bool _is_equal, _is_subset, _is_superset, _is_different;
+    
+    public:
         relation_t(bool equal, bool subset, bool superset, bool different) :
-            _equal(equal), _subset(subset), _superset(superset), _different(different) {}
+            _is_equal(equal), _is_subset(subset), _is_superset(superset), _is_different(different) {}
 
         [[nodiscard]] static relation_t equal();
         [[nodiscard]] static relation_t subset();
         [[nodiscard]] static relation_t superset();
         [[nodiscard]] static relation_t different();
+
+        [[nodiscard]] bool is_equal() const;
+        [[nodiscard]] bool is_subset() const;
+        [[nodiscard]] bool is_superset() const;
+        [[nodiscard]] bool is_different() const;
     };
 
     class DBM {
@@ -87,40 +95,40 @@ namespace pardibaal {
         template<bool is_exact = true>
         [[nodiscard]] relation_t relation(const Federation& fed) const;
 
-        [[nodiscard]] bool equal(const DBM& dbm) const;
+        [[nodiscard]] bool is_equal(const DBM& dbm) const;
 
         template<bool is_exact = true>
-        [[nodiscard]] bool equal(const Federation& fed) const;
+        [[nodiscard]] bool is_equal(const Federation& fed) const;
 
-        [[nodiscard]] bool subset(const DBM& dbm) const;
+        [[nodiscard]] bool is_subset(const DBM& dbm) const;
 
         template<bool is_exact = true>
-        [[nodiscard]] bool subset(const Federation& fed) const;
+        [[nodiscard]] bool is_subset(const Federation& fed) const;
         
-        [[nodiscard]] bool superset(const DBM& dbm) const;
+        [[nodiscard]] bool is_superset(const DBM& dbm) const;
 
         template<bool is_exact = true>
-        [[nodiscard]] bool superset(const Federation& fed) const;
+        [[nodiscard]] bool is_superset(const Federation& fed) const;
 
-        [[nodiscard]] bool different(const DBM& dbm) const;
+        [[nodiscard]] bool is_different(const DBM& dbm) const;
 
         template<bool is_exact = true>
-        [[nodiscard]] bool different(const Federation& fed) const;
+        [[nodiscard]] bool is_different(const Federation& fed) const;
 
         [[nodiscard]] inline relation_t exact_relation(const Federation& fed) const {return this->relation<true>(fed);}
         [[nodiscard]] inline relation_t approx_relation(const Federation& fed) const {return this->relation<false>(fed);}
 
-        [[nodiscard]] inline bool exact_equal(const Federation& fed) const {return this->equal<true>(fed);}
-        [[nodiscard]] inline bool approx_equal(const Federation& fed) const {return this->equal<false>(fed);}
+        [[nodiscard]] inline bool is_exact_equal(const Federation& fed) const {return this->is_equal<true>(fed);}
+        [[nodiscard]] inline bool is_approx_equal(const Federation& fed) const {return this->is_equal<false>(fed);}
 
-        [[nodiscard]] inline bool exact_subset(const Federation& fed) const {return this->subset<true>(fed);}
-        [[nodiscard]] inline bool approx_subset(const Federation& fed) const {return this->subset<false>(fed);}
+        [[nodiscard]] inline bool is_exact_subset(const Federation& fed) const {return this->is_subset<true>(fed);}
+        [[nodiscard]] inline bool is_approx_subset(const Federation& fed) const {return this->is_subset<false>(fed);}
 
-        [[nodiscard]] inline bool exact_superset(const Federation& fed) const {return this->superset<true>(fed);}
-        [[nodiscard]] inline bool approx_superset(const Federation& fed) const {return this->superset<false>(fed);}
+        [[nodiscard]] inline bool is_exact_superset(const Federation& fed) const {return this->is_superset<true>(fed);}
+        [[nodiscard]] inline bool is_approx_superset(const Federation& fed) const {return this->is_superset<false>(fed);}
 
-        [[nodiscard]] inline bool exact_different(const Federation& fed) const {return this->different<true>(fed);}
-        [[nodiscard]] inline bool approx_different(const Federation& fed) const {return this->different<false>(fed);}
+        [[nodiscard]] inline bool is_exact_different(const Federation& fed) const {return this->is_different<true>(fed);}
+        [[nodiscard]] inline bool is_approx_different(const Federation& fed) const {return this->is_different<false>(fed);}
 
         /**
          * Checks if two DBMs intersect ie. if the intersection is non-empty

--- a/src/pardibaal/DBM.h
+++ b/src/pardibaal/DBM.h
@@ -32,7 +32,8 @@
 
 namespace pardibaal {
     class Federation;
-    /** Relation struct
+    /** 
+     * Relation struct
      * represents the relation between two DBMs.
      * different means that they are neither equal or a sub/superset of each other, or the dimensions are different.
      */
@@ -69,15 +70,39 @@ namespace pardibaal {
         [[nodiscard]] bool satisfies(const clock_constraint_t& constraint) const;
         [[nodiscard]] bool satisfies(const std::vector<clock_constraint_t>& constraints) const;
 
+        /**
+         * Exact relation between this dbm and another dbm.
+         * This relation is exact.
+         * @param dbm the rhs of the relation expression.
+         * @return relation_t representing this in relation to dbm
+         */
         [[nodiscard]] relation_t relation(const DBM& dbm) const;
+
+        /**
+         * Relation between this dbm and a federation
+         * This relation is approximate, see Federation::relation
+         * @param fed The rhs of the relation
+         * @return relation_t representing this in relation to fed
+         */
         [[nodiscard]] relation_t relation(const Federation& fed) const;
+
+        /**
+         * Exact relation between this dbm and federation.
+         * This relation is exact but also expensive.
+         * @param fed the rhs of the relation expression.
+         * @return relation_t representing this in relation to fed
+         */
+        [[nodsicard]] relation_t exact_relation(const Federation& fed) const;
 
         [[nodiscard]] bool equal(const DBM& dbm) const;
         [[nodiscard]] bool equal(const Federation& fed) const;
+        [[nodiscard]] bool exact_equal(const Federation& fed) const;
         [[nodiscard]] bool subset(const DBM& dbm) const;
         [[nodiscard]] bool subset(const Federation& fed) const;
+        [[nodiscard]] bool exact_subset(const Federation& fed) const;
         [[nodiscard]] bool superset(const DBM& dbm) const;
         [[nodiscard]] bool superset(const Federation& fed) const;
+        [[nodiscard]] bool exact_superset(const Federation& fed) const;
 
         /**
          * Checks if two DBMs intersect ie. if the intersection is non-empty

--- a/src/pardibaal/DBM.h
+++ b/src/pardibaal/DBM.h
@@ -71,8 +71,8 @@ namespace pardibaal {
         [[nodiscard]] bool satisfies(const std::vector<clock_constraint_t>& constraints) const;
 
         /**
-         * Exact relation between this dbm and another dbm.
-         * This relation is exact.
+         * Relation between this dbm and another dbm.
+         * This relation is always exact.
          * @param dbm the rhs of the relation expression.
          * @return relation_t representing this in relation to dbm
          */
@@ -80,29 +80,47 @@ namespace pardibaal {
 
         /**
          * Relation between this dbm and a federation
-         * This relation is approximate, see Federation::relation
+         * Can be either exact (slow, default) or approximate (fast) see Federation::relation
          * @param fed The rhs of the relation
          * @return relation_t representing this in relation to fed
          */
+        template<bool is_exact = true>
         [[nodiscard]] relation_t relation(const Federation& fed) const;
 
-        /**
-         * Exact relation between this dbm and federation.
-         * This relation is exact but also expensive.
-         * @param fed the rhs of the relation expression.
-         * @return relation_t representing this in relation to fed
-         */
-        [[nodsicard]] relation_t exact_relation(const Federation& fed) const;
-
         [[nodiscard]] bool equal(const DBM& dbm) const;
+
+        template<bool is_exact = true>
         [[nodiscard]] bool equal(const Federation& fed) const;
-        [[nodiscard]] bool exact_equal(const Federation& fed) const;
+
         [[nodiscard]] bool subset(const DBM& dbm) const;
+
+        template<bool is_exact = true>
         [[nodiscard]] bool subset(const Federation& fed) const;
-        [[nodiscard]] bool exact_subset(const Federation& fed) const;
+        
         [[nodiscard]] bool superset(const DBM& dbm) const;
+
+        template<bool is_exact = true>
         [[nodiscard]] bool superset(const Federation& fed) const;
-        [[nodiscard]] bool exact_superset(const Federation& fed) const;
+
+        [[nodiscard]] bool different(const DBM& dbm) const;
+
+        template<bool is_exact = true>
+        [[nodiscard]] bool different(const Federation& fed) const;
+
+        [[nodiscard]] inline relation_t exact_relation(const Federation& fed) const {return this->relation<true>(fed);}
+        [[nodiscard]] inline relation_t approx_relation(const Federation& fed) const {return this->relation<false>(fed);}
+
+        [[nodiscard]] inline bool exact_equal(const Federation& fed) const {return this->equal<true>(fed);}
+        [[nodiscard]] inline bool approx_equal(const Federation& fed) const {return this->equal<false>(fed);}
+
+        [[nodiscard]] inline bool exact_subset(const Federation& fed) const {return this->subset<true>(fed);}
+        [[nodiscard]] inline bool approx_subset(const Federation& fed) const {return this->subset<false>(fed);}
+
+        [[nodiscard]] inline bool exact_superset(const Federation& fed) const {return this->superset<true>(fed);}
+        [[nodiscard]] inline bool approx_superset(const Federation& fed) const {return this->superset<false>(fed);}
+
+        [[nodiscard]] inline bool exact_different(const Federation& fed) const {return this->different<true>(fed);}
+        [[nodiscard]] inline bool approx_different(const Federation& fed) const {return this->different<false>(fed);}
 
         /**
          * Checks if two DBMs intersect ie. if the intersection is non-empty

--- a/src/pardibaal/Federation.cpp
+++ b/src/pardibaal/Federation.cpp
@@ -62,9 +62,9 @@ namespace pardibaal {
         }
 #endif
         auto r = this->relation(dbm);
-        if (r._subset)
+        if (r.is_subset())
             *this = Federation(dbm);
-        if (r._different)
+        if (r.is_different())
             zones.push_back(dbm);
     }
 
@@ -161,10 +161,10 @@ namespace pardibaal {
 
         for (const auto& e : zones) {
             auto relation = e.relation(dbm);
-            if (relation._superset && not relation._equal) return relation;
+            if (relation.is_superset() && not relation.is_equal()) return relation;
 
-            eq = eq || relation._equal;
-            sub = sub && relation._subset;
+            eq = eq || relation.is_equal();
+            sub = sub && relation.is_subset();
         }
 
         if (eq && sub) return relation_t::equal();      // If one dbm is equal and all others are equal/subsets
@@ -206,10 +206,10 @@ namespace pardibaal {
 
             for (const auto& dbm : fed) {
                 auto relation = this->relation(dbm);
-                if (relation._subset && not relation._equal) return relation_t::subset();
+                if (relation.is_subset() && not relation.is_equal()) return relation_t::subset();
 
-                eq = eq || relation._equal;
-                sup = sup && relation._superset;
+                eq = eq || relation.is_equal();
+                sup = sup && relation.is_superset();
             }
 
             // If this is equal to one dbm in fed and supersets/equal to the rest
@@ -225,33 +225,33 @@ namespace pardibaal {
     }
 
     template<bool is_exact=true>
-    bool Federation::equal(const DBM& dbm) const {
-        return this->relation<is_exact>(dbm)._equal;
+    bool Federation::is_equal(const DBM& dbm) const {
+        return this->relation<is_exact>(dbm).is_equal();
     }
 
     template<bool is_exact=true>
-    bool Federation::equal(const Federation& fed) const {
-        return this->relation<is_exact>(fed)._equal;
+    bool Federation::is_equal(const Federation& fed) const {
+        return this->relation<is_exact>(fed).is_equal();
     }
 
     template<bool is_exact=true>
-    bool Federation::subset(const DBM& dbm) const {
-        return this->relation<is_exact>(dbm)._subset;
+    bool Federation::is_subset(const DBM& dbm) const {
+        return this->relation<is_exact>(dbm).is_subset();
     }
 
     template<bool is_exact=true>
-    bool Federation::subset(const Federation& fed) const {
-        return this->relation<is_exact>(fed)._subset;
+    bool Federation::is_subset(const Federation& fed) const {
+        return this->relation<is_exact>(fed).is_subset();
     }
 
     template<bool is_exact=true>
-    bool Federation::superset(const DBM& dbm) const {
-        return this->relation<is_exact>(dbm)._superset;
+    bool Federation::is_superset(const DBM& dbm) const {
+        return this->relation<is_exact>(dbm).is_superset();
     }
 
     template<bool is_exact=true>
-    bool Federation::superset(const Federation& fed) const {
-        return this->relation<is_exact>(fed)._superset;
+    bool Federation::is_superset(const Federation& fed) const {
+        return this->relation<is_exact>(fed).is_superset();
     }
 
 
@@ -260,20 +260,20 @@ namespace pardibaal {
     template relation_t Federation::relation<true>(const Federation& fed) const;
     template relation_t Federation::relation<false>(const Federation& fed) const;
     
-    template bool Federation::equal<true>(const DBM& dbm) const;
-    template bool Federation::equal<false>(const DBM& dbm) const;
-    template bool Federation::equal<true>(const Federation& fed) const;
-    template bool Federation::equal<false>(const Federation& fed) const;
+    template bool Federation::is_equal<true>(const DBM& dbm) const;
+    template bool Federation::is_equal<false>(const DBM& dbm) const;
+    template bool Federation::is_equal<true>(const Federation& fed) const;
+    template bool Federation::is_equal<false>(const Federation& fed) const;
     
-    template bool Federation::subset<true>(const DBM& dbm) const;
-    template bool Federation::subset<false>(const DBM& dbm) const;
-    template bool Federation::subset<true>(const Federation& fed) const;
-    template bool Federation::subset<false>(const Federation& fed) const;
+    template bool Federation::is_subset<true>(const DBM& dbm) const;
+    template bool Federation::is_subset<false>(const DBM& dbm) const;
+    template bool Federation::is_subset<true>(const Federation& fed) const;
+    template bool Federation::is_subset<false>(const Federation& fed) const;
     
-    template bool Federation::superset<true>(const DBM& dbm) const;
-    template bool Federation::superset<false>(const DBM& dbm) const;
-    template bool Federation::superset<true>(const Federation& fed) const;
-    template bool Federation::superset<false>(const Federation& fed) const;
+    template bool Federation::is_superset<true>(const DBM& dbm) const;
+    template bool Federation::is_superset<false>(const DBM& dbm) const;
+    template bool Federation::is_superset<true>(const Federation& fed) const;
+    template bool Federation::is_superset<false>(const Federation& fed) const;
     
 
     bool Federation::intersects(const DBM& dbm) const {

--- a/src/pardibaal/Federation.cpp
+++ b/src/pardibaal/Federation.cpp
@@ -233,7 +233,7 @@ namespace pardibaal {
                 g_subeq = g_subeq && subeq;
             }
 
-            for (const auto& b : supereq)
+            for (const auto b : supereq)
                 g_supereq = g_supereq && b;
 
             /* If g_subeq is true, then all dbm in lhs are included in rhs 

--- a/src/pardibaal/Federation.cpp
+++ b/src/pardibaal/Federation.cpp
@@ -145,7 +145,7 @@ namespace pardibaal {
         return true;
     }
 
-    template<bool is_exact = true>
+    template<bool is_exact>
     relation_t Federation::relation(const DBM& dbm) const {
         if (is_exact)
             return this->relation<true>(Federation(dbm));
@@ -178,7 +178,7 @@ namespace pardibaal {
         return relation_t::subset(); // If no dbm is equal/different/supersets, then all must be subsets
     }
 
-    template<bool is_exact = true>
+    template<bool is_exact>
     relation_t Federation::relation(const Federation& fed) const {
         if (this->is_empty())
             return fed.is_empty() ? relation_t::equal() : relation_t::subset();
@@ -246,32 +246,32 @@ namespace pardibaal {
         return relation_t::different();
     }
 
-    template<bool is_exact=true>
+    template<bool is_exact>
     bool Federation::is_equal(const DBM& dbm) const {
         return this->relation<is_exact>(dbm).is_equal();
     }
 
-    template<bool is_exact=true>
+    template<bool is_exact>
     bool Federation::is_equal(const Federation& fed) const {
         return this->relation<is_exact>(fed).is_equal();
     }
 
-    template<bool is_exact=true>
+    template<bool is_exact>
     bool Federation::is_subset(const DBM& dbm) const {
         return this->relation<is_exact>(dbm).is_subset();
     }
 
-    template<bool is_exact=true>
+    template<bool is_exact>
     bool Federation::is_subset(const Federation& fed) const {
         return this->relation<is_exact>(fed).is_subset();
     }
 
-    template<bool is_exact=true>
+    template<bool is_exact>
     bool Federation::is_superset(const DBM& dbm) const {
         return this->relation<is_exact>(dbm).is_superset();
     }
 
-    template<bool is_exact=true>
+    template<bool is_exact>
     bool Federation::is_superset(const Federation& fed) const {
         return this->relation<is_exact>(fed).is_superset();
     }

--- a/src/pardibaal/Federation.cpp
+++ b/src/pardibaal/Federation.cpp
@@ -215,15 +215,20 @@ namespace pardibaal {
 
             for (const auto& dbm1 : this->zones) {
                 bool subeq = false; // If this dbm is included in the rhs
+                bool check_super = true; // Used for early termination when a single DBM includes all of fed
                 
                 int i = 0;
                 for (const auto& dbm2 : fed) {
                     auto rel = dbm1.relation(dbm2);
 
+                    check_super = check_super && rel.is_superset();
+
                     subeq = subeq || rel.is_equal() || rel.is_subset();
                     supereq[i] = supereq[i] || rel.is_superset() || rel.is_equal();
                     ++i;
                 }
+
+                if (check_super) return relation_t::superset();
 
                 g_subeq = g_subeq && subeq;
             }

--- a/src/pardibaal/Federation.cpp
+++ b/src/pardibaal/Federation.cpp
@@ -150,6 +150,8 @@ namespace pardibaal {
             return dbm.is_empty() ? relation_t::equal() : relation_t::subset();
         if (dbm.is_empty())
             return relation_t::superset();
+        if (this->dimension() != dbm.dimension())
+            return relation_t::different();
 
         bool eq = false, sub = true;
 
@@ -173,6 +175,8 @@ namespace pardibaal {
             return fed.is_empty() ? relation_t::equal() : relation_t::subset();
         if (fed.is_empty())
             return relation_t::superset();
+        if (this->dimension() != fed.dimension())
+            return relation_t::different();
 
         bool eq = false, sup = true;
 

--- a/src/pardibaal/Federation.cpp
+++ b/src/pardibaal/Federation.cpp
@@ -147,7 +147,7 @@ namespace pardibaal {
 
     template<bool is_exact>
     relation_t Federation::relation(const DBM& dbm) const {
-        if (is_exact)
+        if constexpr(is_exact)
             return this->relation<true>(Federation(dbm));
         
         if (this->is_empty())
@@ -187,7 +187,7 @@ namespace pardibaal {
         if (this->dimension() != fed.dimension())
             return relation_t::different();
 
-        if (is_exact) {
+        if constexpr(is_exact) {
             
             auto fed1 = *this;
             auto fed2 = fed;

--- a/src/pardibaal/Federation.cpp
+++ b/src/pardibaal/Federation.cpp
@@ -145,7 +145,7 @@ namespace pardibaal {
         return true;
     }
 
-    template<bool is_exact>
+    template<bool is_exact = true>
     relation_t Federation::relation(const DBM& dbm) const {
         if (is_exact)
             return this->relation<true>(Federation(dbm));
@@ -178,7 +178,7 @@ namespace pardibaal {
         return relation_t::subset(); // If no dbm is equal/different/supersets, then all must be subsets
     }
 
-    template<bool is_exact>
+    template<bool is_exact = true>
     relation_t Federation::relation(const Federation& fed) const {
         if (this->is_empty())
             return fed.is_empty() ? relation_t::equal() : relation_t::subset();

--- a/src/pardibaal/Federation.cpp
+++ b/src/pardibaal/Federation.cpp
@@ -196,12 +196,49 @@ namespace pardibaal {
         return relation_t::different();
     }
 
+    relation_t Federation::exact_relation(const DBM& dbm) const {
+        return this->exact_relation(Federation(dbm));
+    }
+
+    relation_t Federation::exact_relation(const Federation& fed) const {
+        if (this->is_empty())
+            return fed.is_empty() ? relation_t::equal() : relation_t::subset();
+        if (fed.is_empty())
+            return relation_t::superset();
+        if (this->dimension() != fed.dimension())
+            return relation_t::different();
+        
+        auto fed1 = *this;
+        auto fed2 = fed;
+
+        fed1.subtract(fed);
+        fed2.subtract(*this);
+        
+        if (fed1.is_empty()) {
+            if (fed2.is_empty())
+                return relation_t::equal();
+            return relation_t::subset();
+        } 
+        if (fed2.is_empty())
+            return relation_t::superset();
+
+        return relation_t::different();
+    }
+
     bool Federation::equal(const DBM& dbm) const {
         return this->relation(dbm)._equal;
     }
 
     bool Federation::equal(const Federation& fed) const {
         return this->relation(fed)._equal;
+    }
+
+    bool Federation::exact_equal(const DBM& dbm) const {
+        return this->exact_relation(dbm)._equal;
+    }
+
+    bool Federation::exact_equal(const Federation& fed) const {
+        return this->exact_relation(fed)._equal;
     }
 
     bool Federation::subset(const DBM& dbm) const {
@@ -212,6 +249,14 @@ namespace pardibaal {
         return this->relation(fed)._subset;
     }
 
+    bool Federation::exact_subset(const DBM& dbm) const {
+        return this->exact_relation(dbm)._subset;
+    }
+
+    bool Federation::exact_subset(const Federation& fed) const {
+        return this->exact_relation(fed)._subset;
+    }
+
     bool Federation::superset(const DBM& dbm) const {
         return this->relation(dbm)._superset;
     }
@@ -219,6 +264,15 @@ namespace pardibaal {
     bool Federation::superset(const Federation& fed) const {
         return this->relation(fed)._superset;
     }
+
+    bool Federation::exact_superset(const DBM& dbm) const {
+        return this->exact_relation(dbm)._superset;
+    }
+
+    bool Federation::exact_superset(const Federation& fed) const {
+        return this->exact_relation(fed)._superset;
+    }
+
 
     bool Federation::intersects(const DBM& dbm) const {
         return std::any_of(this->begin(), this->end(), [&dbm](const DBM& z){return z.intersects(dbm);});

--- a/src/pardibaal/Federation.h
+++ b/src/pardibaal/Federation.h
@@ -154,7 +154,7 @@ namespace pardibaal {
          * @return true if the dbm and federation includes the exact same space.
          */
         template<bool is_exact=true>
-        [[nodiscard]] bool equal(const DBM& dbm) const;
+        [[nodiscard]] bool is_equal(const DBM& dbm) const;
 
         /**
          * Checks if the federations are equal.
@@ -163,7 +163,7 @@ namespace pardibaal {
          * @return true if the federations includes the exact same space.
          */
         template<bool is_exact=true>
-        [[nodiscard]] bool equal(const Federation& fed) const;
+        [[nodiscard]] bool is_equal(const Federation& fed) const;
 
 
         /**
@@ -173,7 +173,7 @@ namespace pardibaal {
          * @return true if this is included in the dbm
          */
         template<bool is_exact=true>
-        [[nodiscard]] bool subset(const DBM& dbm) const;
+        [[nodiscard]] bool is_subset(const DBM& dbm) const;
 
 
         /**
@@ -183,7 +183,7 @@ namespace pardibaal {
          * @return true if this is included in fed
          */
         template<bool is_exact=true>
-        [[nodiscard]] bool subset(const Federation& fed) const;
+        [[nodiscard]] bool is_subset(const Federation& fed) const;
 
 
         /**
@@ -193,7 +193,7 @@ namespace pardibaal {
          * @return true if this includes the dbm
          */
         template<bool is_exact=true>
-        [[nodiscard]] bool superset(const DBM& dbm) const;
+        [[nodiscard]] bool is_superset(const DBM& dbm) const;
 
         
         /**
@@ -203,27 +203,27 @@ namespace pardibaal {
          * @return true if this includes fed
          */
         template<bool is_exact=true>
-        [[nodiscard]] bool superset(const Federation& fed) const;
+        [[nodiscard]] bool is_superset(const Federation& fed) const;
 
         [[nodiscard]] inline relation_t exact_relation(const DBM& dbm) const {return this->relation<true>(dbm);}
         [[nodiscard]] inline relation_t approx_relation(const DBM& dbm) const {return this->relation<false>(dbm);}
         [[nodiscard]] inline relation_t exact_relation(const Federation& fed) const {return this->relation<true>(fed);}
         [[nodiscard]] inline relation_t approx_relation(const Federation& fed) const {return this->relation<false>(fed);}
 
-        [[nodiscard]] inline bool exact_equal(const DBM& dbm) const {return this->equal<true>(dbm);}
-        [[nodiscard]] inline bool approx_equal(const DBM& dbm) const {return this->equal<false>(dbm);}
-        [[nodiscard]] inline bool exact_equal(const Federation& fed) const {return this->equal<true>(fed);}
-        [[nodiscard]] inline bool approx_equal(const Federation& fed) const {return this->equal<false>(fed);}
+        [[nodiscard]] inline bool is_exact_equal(const DBM& dbm) const {return this->is_equal<true>(dbm);}
+        [[nodiscard]] inline bool is_approx_equal(const DBM& dbm) const {return this->is_equal<false>(dbm);}
+        [[nodiscard]] inline bool is_exact_equal(const Federation& fed) const {return this->is_equal<true>(fed);}
+        [[nodiscard]] inline bool is_approx_equal(const Federation& fed) const {return this->is_equal<false>(fed);}
 
-        [[nodiscard]] inline bool exact_subset(const DBM& dbm) const {return this->subset<true>(dbm);}
-        [[nodiscard]] inline bool approx_subset(const DBM& dbm) const {return this->subset<false>(dbm);}
-        [[nodiscard]] inline bool exact_subset(const Federation& fed) const {return this->subset<true>(fed);}
-        [[nodiscard]] inline bool approx_subset(const Federation& fed) const {return this->subset<false>(fed);}
+        [[nodiscard]] inline bool is_exact_subset(const DBM& dbm) const {return this->is_subset<true>(dbm);}
+        [[nodiscard]] inline bool is_approx_subset(const DBM& dbm) const {return this->is_subset<false>(dbm);}
+        [[nodiscard]] inline bool is_exact_subset(const Federation& fed) const {return this->is_subset<true>(fed);}
+        [[nodiscard]] inline bool is_approx_subset(const Federation& fed) const {return this->is_subset<false>(fed);}
 
-        [[nodiscard]] inline bool exact_superset(const DBM& dbm) const {return this->superset<true>(dbm);}
-        [[nodiscard]] inline bool approx_superset(const DBM& dbm) const {return this->superset<false>(dbm);}
-        [[nodiscard]] inline bool exact_superset(const Federation& fed) const {return this->superset<true>(fed);}
-        [[nodiscard]] inline bool approx_superset(const Federation& fed) const {return this->superset<false>(fed);}
+        [[nodiscard]] inline bool is_exact_superset(const DBM& dbm) const {return this->is_superset<true>(dbm);}
+        [[nodiscard]] inline bool is_approx_superset(const DBM& dbm) const {return this->is_superset<false>(dbm);}
+        [[nodiscard]] inline bool is_exact_superset(const Federation& fed) const {return this->is_superset<true>(fed);}
+        [[nodiscard]] inline bool is_approx_superset(const Federation& fed) const {return this->is_superset<false>(fed);}
 
         /**
          * Checks if a federation intersect with a federation ie. if the intersection is non-empty

--- a/src/pardibaal/Federation.h
+++ b/src/pardibaal/Federation.h
@@ -127,136 +127,104 @@ namespace pardibaal {
 
         /**
          * Relation between this and a dbm.
-         * The relation is an under-approximation.
-         * Can possibly return different, even though it is equal/subset/superset.
-         * If it returns equal, subset, or superset it is always true.
-         * @param dbm the rhs of the relation expression.
-         * @return relation_t representing this in relation to dbm.
+         * The non-exact relation is an under-approximation.
+         * If it returns different, it might be equal subset, or superset.
+         * The exact relation is computationally expensive.
+         * @param fed the rhs (federation) of the relation expression.
+         * @return relation_t representing this in relation to fed.
          */
+        template<bool is_exact=true>
         [[nodiscard]] relation_t relation(const DBM& dbm) const;
 
         /**
          * Relation between this and another federation.
-         * The relation is an under-approximation.
-         * If it returns different, it might actually be equal subset, or superset.
-         * If it returns equal, subset, or superset it is always true.
+         * The non-exact relation is an under-approximation.
+         * If it returns different, it might be equal subset, or superset.
+         * The exact relation is computationally expensive.
          * @param fed the rhs (federation) of the relation expression.
          * @return relation_t representing this in relation to fed.
          */
+        template<bool is_exact=true>
         [[nodiscard]] relation_t relation(const Federation& fed) const;
 
         /**
-         * Exact relation between this and a dbm.
-         * This relation is exact but also expensive.
-         * @param dbm the rhs of the relation expression.
-         * @return relation_t representing this in relation to the dbm
-         */
-        [[nodiscard]] relation_t exact_relation(const DBM& dbm) const;
-
-        /**
-         * Exact relation between this and another federation.
-         * This relation is exact but also expensive.
-         * @param fed the rhs of the relation expression.
-         * @return relation_t representing this in relation to fed
-         */
-        [[nodiscard]] relation_t exact_relation(const Federation& fed) const;
-
-        /**
          * Checks if this is equal to the dbm.
-         * This is an under-approximation, see Federation::relation
+         * The non-exact is an under-approximation, see Federation::relation<false>
          * @param dbm rhs of the equality.
          * @return true if the dbm and federation includes the exact same space.
          */
+        template<bool is_exact=true>
         [[nodiscard]] bool equal(const DBM& dbm) const;
 
         /**
          * Checks if the federations are equal.
-         * This is an under-approximation, see Federation::relation
+         * The non-exact is an under-approximation, see Federation::relation<false>
          * @param fed rhs of the equality.
          * @return true if the federations includes the exact same space.
          */
+        template<bool is_exact=true>
         [[nodiscard]] bool equal(const Federation& fed) const;
 
-        /**
-         * Checks if this is equal to the dbm.
-         * This is an exact relation see Federation::exact_relation
-         * @param dbm rhs of the equality.
-         * @return true if the dbm and federation includes the exact same space.
-         */
-        [[nodiscard]] bool exact_equal(const DBM& dbm) const;
-
-        /**
-         * Checks if the federations are equal.
-         * This is an exact relation see Federation::exact_relation
-         * @param fed rhs of the equality.
-         * @return true if the federations includes the exact same space.
-         */
-        [[nodiscard]] bool exact_equal(const Federation& fed) const;
 
         /**
          * Checks if this is a subset of or included in the dbm.
-         * This is an under-approximation, see Federation::relation
+         * The non-exact is an under-approximation, see Federation::relation<false>
          * @param dbm rhs of the relation.
          * @return true if this is included in the dbm
          */
+        template<bool is_exact=true>
         [[nodiscard]] bool subset(const DBM& dbm) const;
+
 
         /**
          * Checks if this is a subset of or included in the federation.
-         * This is an under-approximation, see Federation::relation
+         * The non-exact is an under-approximation, see Federation::relation<false>
          * @param fed rhs of the relation.
          * @return true if this is included in fed
          */
+        template<bool is_exact=true>
         [[nodiscard]] bool subset(const Federation& fed) const;
 
-        /**
-         * Checks if this is a subset of the dbm.
-         * This is an exact relation see Federation::exact_relation
-         * @param dbm rhs of the comparison.
-         * @return true if this is included in the dbm.
-         */
-        [[nodiscard]] bool exact_subset(const DBM& dbm) const;
-        
-        /**
-         * Checks if this is a subset of the federation.
-         * This is an exact relation see Federation::exact_relation
-         * @param fed rhs of the comparison.
-         * @return true if this is included in the federation.
-         */
-        [[nodiscard]] bool exact_subset(const Federation& fed) const;
 
         /**
          * Checks if this is a superset of or includes the dbm.
-         * This is an under-approximation, see Federation::relation
+         * The non-exact is an under-approximation, see Federation::relation<false>
          * @param dbm rhs of the relation.
          * @return true if this includes the dbm
          */
+        template<bool is_exact=true>
         [[nodiscard]] bool superset(const DBM& dbm) const;
 
+        
         /**
          * Checks if this is a superset of or includes the federation.
-         * This is an under-approximation, see Federation::relation
+         * The non-exact is an under-approximation, see Federation::relation<false>
          * @param fed rhs of the relation.
          * @return true if this includes fed
          */
+        template<bool is_exact=true>
         [[nodiscard]] bool superset(const Federation& fed) const;
 
-        /**
-         * Checks if this is a superset of the dbm.
-         * This is an exact relation see Federation::exact_relation
-         * @param dbm rhs of the comparison.
-         * @return true if this includes the dbm.
-         */
-        [[nodiscard]] bool exact_superset(const DBM& dbm) const;
-        
-        /**
-         * Checks if this is a superset of the federation.
-         * This is an exact relation see Federation::exact_relation
-         * @param fed rhs of the comparison.
-         * @return true if this includes the federation.
-         */
-        [[nodiscard]] bool exact_superset(const Federation& fed) const;
-        
+        [[nodiscard]] inline relation_t exact_relation(const DBM& dbm) const {return this->relation<true>(dbm);}
+        [[nodiscard]] inline relation_t approx_relation(const DBM& dbm) const {return this->relation<false>(dbm);}
+        [[nodiscard]] inline relation_t exact_relation(const Federation& fed) const {return this->relation<true>(fed);}
+        [[nodiscard]] inline relation_t approx_relation(const Federation& fed) const {return this->relation<false>(fed);}
+
+        [[nodiscard]] inline bool exact_equal(const DBM& dbm) const {return this->equal<true>(dbm);}
+        [[nodiscard]] inline bool approx_equal(const DBM& dbm) const {return this->equal<false>(dbm);}
+        [[nodiscard]] inline bool exact_equal(const Federation& fed) const {return this->equal<true>(fed);}
+        [[nodiscard]] inline bool approx_equal(const Federation& fed) const {return this->equal<false>(fed);}
+
+        [[nodiscard]] inline bool exact_subset(const DBM& dbm) const {return this->subset<true>(dbm);}
+        [[nodiscard]] inline bool approx_subset(const DBM& dbm) const {return this->subset<false>(dbm);}
+        [[nodiscard]] inline bool exact_subset(const Federation& fed) const {return this->subset<true>(fed);}
+        [[nodiscard]] inline bool approx_subset(const Federation& fed) const {return this->subset<false>(fed);}
+
+        [[nodiscard]] inline bool exact_superset(const DBM& dbm) const {return this->superset<true>(dbm);}
+        [[nodiscard]] inline bool approx_superset(const DBM& dbm) const {return this->superset<false>(dbm);}
+        [[nodiscard]] inline bool exact_superset(const Federation& fed) const {return this->superset<true>(fed);}
+        [[nodiscard]] inline bool approx_superset(const Federation& fed) const {return this->superset<false>(fed);}
+
         /**
          * Checks if a federation intersect with a federation ie. if the intersection is non-empty
          * @return true if this intersects with dbm

--- a/src/pardibaal/Federation.h
+++ b/src/pardibaal/Federation.h
@@ -89,6 +89,7 @@ namespace pardibaal {
          * @param fed The federation to be subtracted.
          */
         void subtract(const Federation& fed);
+
         void remove(dim_t index);
 
 
@@ -145,10 +146,26 @@ namespace pardibaal {
         [[nodiscard]] relation_t relation(const Federation& fed) const;
 
         /**
+         * Exact relation between this and a dbm.
+         * This relation is exact but also expensive.
+         * @param dbm the rhs of the relation expression.
+         * @return relation_t representing this in relation to the dbm
+         */
+        [[nodiscard]] relation_t exact_relation(const DBM& dbm) const;
+
+        /**
+         * Exact relation between this and another federation.
+         * This relation is exact but also expensive.
+         * @param fed the rhs of the relation expression.
+         * @return relation_t representing this in relation to fed
+         */
+        [[nodiscard]] relation_t exact_relation(const Federation& fed) const;
+
+        /**
          * Checks if this is equal to the dbm.
          * This is an under-approximation, see Federation::relation
          * @param dbm rhs of the equality.
-         * @return true if the dbm and federation includes the same space.
+         * @return true if the dbm and federation includes the exact same space.
          */
         [[nodiscard]] bool equal(const DBM& dbm) const;
 
@@ -156,9 +173,25 @@ namespace pardibaal {
          * Checks if the federations are equal.
          * This is an under-approximation, see Federation::relation
          * @param fed rhs of the equality.
-         * @return true if the federations includes the same space.
+         * @return true if the federations includes the exact same space.
          */
         [[nodiscard]] bool equal(const Federation& fed) const;
+
+        /**
+         * Checks if this is equal to the dbm.
+         * This is an exact relation see Federation::exact_relation
+         * @param dbm rhs of the equality.
+         * @return true if the dbm and federation includes the exact same space.
+         */
+        [[nodiscard]] bool exact_equal(const DBM& dbm) const;
+
+        /**
+         * Checks if the federations are equal.
+         * This is an exact relation see Federation::exact_relation
+         * @param fed rhs of the equality.
+         * @return true if the federations includes the exact same space.
+         */
+        [[nodiscard]] bool exact_equal(const Federation& fed) const;
 
         /**
          * Checks if this is a subset of or included in the dbm.
@@ -177,6 +210,22 @@ namespace pardibaal {
         [[nodiscard]] bool subset(const Federation& fed) const;
 
         /**
+         * Checks if this is a subset of the dbm.
+         * This is an exact relation see Federation::exact_relation
+         * @param dbm rhs of the comparison.
+         * @return true if this is included in the dbm.
+         */
+        [[nodiscard]] bool exact_subset(const DBM& dbm) const;
+        
+        /**
+         * Checks if this is a subset of the federation.
+         * This is an exact relation see Federation::exact_relation
+         * @param fed rhs of the comparison.
+         * @return true if this is included in the federation.
+         */
+        [[nodiscard]] bool exact_subset(const Federation& fed) const;
+
+        /**
          * Checks if this is a superset of or includes the dbm.
          * This is an under-approximation, see Federation::relation
          * @param dbm rhs of the relation.
@@ -192,6 +241,22 @@ namespace pardibaal {
          */
         [[nodiscard]] bool superset(const Federation& fed) const;
 
+        /**
+         * Checks if this is a superset of the dbm.
+         * This is an exact relation see Federation::exact_relation
+         * @param dbm rhs of the comparison.
+         * @return true if this includes the dbm.
+         */
+        [[nodiscard]] bool exact_superset(const DBM& dbm) const;
+        
+        /**
+         * Checks if this is a superset of the federation.
+         * This is an exact relation see Federation::exact_relation
+         * @param fed rhs of the comparison.
+         * @return true if this includes the federation.
+         */
+        [[nodiscard]] bool exact_superset(const Federation& fed) const;
+        
         /**
          * Checks if a federation intersect with a federation ie. if the intersection is non-empty
          * @return true if this intersects with dbm

--- a/src/pardibaal/Federation.h
+++ b/src/pardibaal/Federation.h
@@ -133,7 +133,7 @@ namespace pardibaal {
          * @param fed the rhs (federation) of the relation expression.
          * @return relation_t representing this in relation to fed.
          */
-        template<bool is_exact=true>
+        template<bool is_exact = true>
         [[nodiscard]] relation_t relation(const DBM& dbm) const;
 
         /**
@@ -144,7 +144,7 @@ namespace pardibaal {
          * @param fed the rhs (federation) of the relation expression.
          * @return relation_t representing this in relation to fed.
          */
-        template<bool is_exact=true>
+        template<bool is_exact = true>
         [[nodiscard]] relation_t relation(const Federation& fed) const;
 
         /**
@@ -153,7 +153,7 @@ namespace pardibaal {
          * @param dbm rhs of the equality.
          * @return true if the dbm and federation includes the exact same space.
          */
-        template<bool is_exact=true>
+        template<bool is_exact = true>
         [[nodiscard]] bool is_equal(const DBM& dbm) const;
 
         /**
@@ -162,7 +162,7 @@ namespace pardibaal {
          * @param fed rhs of the equality.
          * @return true if the federations includes the exact same space.
          */
-        template<bool is_exact=true>
+        template<bool is_exact = true>
         [[nodiscard]] bool is_equal(const Federation& fed) const;
 
 
@@ -172,7 +172,7 @@ namespace pardibaal {
          * @param dbm rhs of the relation.
          * @return true if this is included in the dbm
          */
-        template<bool is_exact=true>
+        template<bool is_exact = true>
         [[nodiscard]] bool is_subset(const DBM& dbm) const;
 
 
@@ -182,7 +182,7 @@ namespace pardibaal {
          * @param fed rhs of the relation.
          * @return true if this is included in fed
          */
-        template<bool is_exact=true>
+        template<bool is_exact = true>
         [[nodiscard]] bool is_subset(const Federation& fed) const;
 
 
@@ -192,7 +192,7 @@ namespace pardibaal {
          * @param dbm rhs of the relation.
          * @return true if this includes the dbm
          */
-        template<bool is_exact=true>
+        template<bool is_exact = true>
         [[nodiscard]] bool is_superset(const DBM& dbm) const;
 
         
@@ -202,7 +202,7 @@ namespace pardibaal {
          * @param fed rhs of the relation.
          * @return true if this includes fed
          */
-        template<bool is_exact=true>
+        template<bool is_exact = true>
         [[nodiscard]] bool is_superset(const Federation& fed) const;
 
         [[nodiscard]] inline relation_t exact_relation(const DBM& dbm) const {return this->relation<true>(dbm);}

--- a/test/DBM_test.cpp
+++ b/test/DBM_test.cpp
@@ -79,8 +79,8 @@ BOOST_AUTO_TEST_CASE(bounded_future_test_2) {
 
     D.future(0);
 
-    BOOST_CHECK(D.equal(Z));
-    BOOST_CHECK(Z.equal(D));
+    BOOST_CHECK(D.is_equal(Z));
+    BOOST_CHECK(Z.is_equal(D));
 }
 
 BOOST_AUTO_TEST_CASE(delay_test_1) {
@@ -104,8 +104,8 @@ BOOST_AUTO_TEST_CASE(delay_test_2) {
 
     D.delay(0);
 
-    BOOST_CHECK(D.equal(Z));
-    BOOST_CHECK(Z.equal(D));
+    BOOST_CHECK(D.is_equal(Z));
+    BOOST_CHECK(Z.is_equal(D));
 }
 
 BOOST_AUTO_TEST_CASE(interval_delay_test_1) {
@@ -114,8 +114,8 @@ BOOST_AUTO_TEST_CASE(interval_delay_test_1) {
     D.interval_delay(0, 5);
     Z.future(5);
 
-    BOOST_CHECK(D.equal(Z));
-    BOOST_CHECK(Z.equal(D));
+    BOOST_CHECK(D.is_equal(Z));
+    BOOST_CHECK(Z.is_equal(D));
 }
 
 BOOST_AUTO_TEST_CASE(interval_delay_test_2) {
@@ -125,8 +125,8 @@ BOOST_AUTO_TEST_CASE(interval_delay_test_2) {
     Z.delay(2);
     Z.future(3);
 
-    BOOST_CHECK(D.equal(Z));
-    BOOST_CHECK(Z.equal(D));
+    BOOST_CHECK(D.is_equal(Z));
+    BOOST_CHECK(Z.is_equal(D));
 }
 
 BOOST_AUTO_TEST_CASE(restrict_test_1) {
@@ -779,7 +779,7 @@ BOOST_AUTO_TEST_CASE(intersection_test_1) {
 
     dbm1.intersection(dbm2);
 
-    BOOST_CHECK(dbm1.equal(dbm2));
+    BOOST_CHECK(dbm1.is_equal(dbm2));
 }
 
 BOOST_AUTO_TEST_CASE(intersection_test_2) {
@@ -842,14 +842,14 @@ BOOST_AUTO_TEST_CASE(relation_test_1) {
     DBM D1(2);
     DBM D2(3);
 
-    BOOST_CHECK(D1.relation(D2)._different);
-    BOOST_CHECK(not D1.equal(D2));
-    BOOST_CHECK(not D1.subset(D2));
-    BOOST_CHECK(not D1.superset(D2));
-    BOOST_CHECK(D2.relation(D1)._different);
-    BOOST_CHECK(not D2.equal(D1));
-    BOOST_CHECK(not D2.subset(D1));
-    BOOST_CHECK(not D2.superset(D1));
+    BOOST_CHECK(D1.relation(D2).is_different());
+    BOOST_CHECK(not D1.is_equal(D2));
+    BOOST_CHECK(not D1.is_subset(D2));
+    BOOST_CHECK(not D1.is_superset(D2));
+    BOOST_CHECK(D2.relation(D1).is_different());
+    BOOST_CHECK(not D2.is_equal(D1));
+    BOOST_CHECK(not D2.is_subset(D1));
+    BOOST_CHECK(not D2.is_superset(D1));
 }
 
 BOOST_AUTO_TEST_CASE(relation_test_2) {
@@ -858,17 +858,17 @@ BOOST_AUTO_TEST_CASE(relation_test_2) {
 
     D2.future();
 
-    BOOST_CHECK(D1.relation(D2)._subset);
-    BOOST_CHECK(D1.subset(D2));
-    BOOST_CHECK(D2.relation(D1)._superset);
-    BOOST_CHECK(D2.superset(D1));
+    BOOST_CHECK(D1.relation(D2).is_subset());
+    BOOST_CHECK(D1.is_subset(D2));
+    BOOST_CHECK(D2.relation(D1).is_superset());
+    BOOST_CHECK(D2.is_superset(D1));
 
     D1.free(1);
 
-    BOOST_CHECK(D1.relation(D2)._equal);
-    BOOST_CHECK(D1.equal(D2));
-    BOOST_CHECK(D2.relation(D1)._equal);
-    BOOST_CHECK(D2.equal(D1));
+    BOOST_CHECK(D1.relation(D2).is_equal());
+    BOOST_CHECK(D1.is_equal(D2));
+    BOOST_CHECK(D2.relation(D1).is_equal());
+    BOOST_CHECK(D2.is_equal(D1));
 }
 
 BOOST_AUTO_TEST_CASE(relation_test_3) {
@@ -878,34 +878,34 @@ BOOST_AUTO_TEST_CASE(relation_test_3) {
     D1.assign(1, 10);
     D2.assign(1, 5);
 
-    BOOST_CHECK(D1.relation(D2)._different);
-    BOOST_CHECK(not D1.equal(D2));
-    BOOST_CHECK(not D1.subset(D2));
-    BOOST_CHECK(not D1.superset(D2));
+    BOOST_CHECK(D1.relation(D2).is_different());
+    BOOST_CHECK(not D1.is_equal(D2));
+    BOOST_CHECK(not D1.is_subset(D2));
+    BOOST_CHECK(not D1.is_superset(D2));
 
     D1.future();
     D2.future();
 
-    BOOST_CHECK(D1.relation(D2)._subset);
-    BOOST_CHECK(D1.subset(D2));
-    BOOST_CHECK(D2.relation(D1)._superset);
-    BOOST_CHECK(D2.superset(D1));
-    BOOST_CHECK(not D2.relation(D1)._equal);
-    BOOST_CHECK(not D2.equal(D1));
+    BOOST_CHECK(D1.relation(D2).is_subset());
+    BOOST_CHECK(D1.is_subset(D2));
+    BOOST_CHECK(D2.relation(D1).is_superset());
+    BOOST_CHECK(D2.is_superset(D1));
+    BOOST_CHECK(not D2.relation(D1).is_equal());
+    BOOST_CHECK(not D2.is_equal(D1));
 
     D1.assign(1, 10);
 
-    BOOST_CHECK(D1.relation(D2)._subset);
-    BOOST_CHECK(D1.subset(D2));
-    BOOST_CHECK(not D1.superset(D2));
+    BOOST_CHECK(D1.relation(D2).is_subset());
+    BOOST_CHECK(D1.is_subset(D2));
+    BOOST_CHECK(not D1.is_superset(D2));
 
-    BOOST_CHECK(D2.relation(D1)._superset);
-    BOOST_CHECK(D2.superset(D1));
-    BOOST_CHECK(not D2.subset(D1));
+    BOOST_CHECK(D2.relation(D1).is_superset());
+    BOOST_CHECK(D2.is_superset(D1));
+    BOOST_CHECK(not D2.is_subset(D1));
 
-    BOOST_CHECK(!D2.relation(D1)._equal);
-    BOOST_CHECK(not D2.equal(D1));
-    BOOST_CHECK(not D1.equal(D2));
+    BOOST_CHECK(!D2.relation(D1).is_equal());
+    BOOST_CHECK(not D2.is_equal(D1));
+    BOOST_CHECK(not D1.is_equal(D2));
 }
 
 BOOST_AUTO_TEST_CASE(relation_test_4) {
@@ -913,7 +913,7 @@ BOOST_AUTO_TEST_CASE(relation_test_4) {
 
     a.future();
 
-    BOOST_CHECK(a.equal(b));
+    BOOST_CHECK(a.is_equal(b));
 }
 
 BOOST_AUTO_TEST_CASE(intersects_test_1) {
@@ -969,7 +969,7 @@ BOOST_AUTO_TEST_CASE(zero_test_1) {
         for (dim_t j = 0; j < dimension; ++j)
             dbm.set(i, j, bound_t::non_strict(0));
 
-    BOOST_CHECK(DBM::zero(dimension).equal(dbm));
+    BOOST_CHECK(DBM::zero(dimension).is_equal(dbm));
 }
 
 BOOST_AUTO_TEST_CASE(unconstrained_test_1) {
@@ -984,5 +984,5 @@ BOOST_AUTO_TEST_CASE(unconstrained_test_1) {
         }
     }
 
-    BOOST_CHECK(DBM::unconstrained(dimension).equal(dbm));
+    BOOST_CHECK(DBM::unconstrained(dimension).is_equal(dbm));
 }

--- a/test/Federation_test.cpp
+++ b/test/Federation_test.cpp
@@ -236,6 +236,207 @@ BOOST_AUTO_TEST_CASE(relation_test_5) {
     BOOST_CHECK(fed2.subset(fed1));
 }
 
+BOOST_AUTO_TEST_CASE(relation_test_6) {
+    auto fed1 = Federation::zero(3),
+         fed2 = Federation::zero(3);
+    auto dbm1 = DBM::unconstrained(3),
+         dbm2 = DBM::unconstrained(3);
+    
+    dbm1.restrict(clock_constraint_t::upper_non_strict(1, 10));
+    dbm2.restrict(clock_constraint_t::lower_strict(1, 10));
+
+    dbm1.restrict(clock_constraint_t::upper_non_strict(2, 5));
+    dbm2.restrict(clock_constraint_t::lower_strict(2, 5));
+
+    BOOST_CHECK(dbm1.relation(dbm2).different);
+    BOOST_CHECK(dbm2.relation(dbm1).different);
+
+    fed1.add(dbm1);
+    fed1.add(dbm2);
+    fed2.add(dbm1);
+    fed2.add(dbm2);
+
+    auto approx1 = fed1.relation(fed2);
+    auto approx2 = fed2.relation(fed1);
+
+    BOOST_CHECK(fed1.superset(dbm1));
+    BOOST_CHECK(fed1.superset(dbm2));
+    BOOST_CHECK(fed2.superset(dbm1));
+    BOOST_CHECK(fed2.superset(dbm2));
+    BOOST_CHECK(approx1._superset);
+    BOOST_CHECK(approx2._superset);
+}
+
+BOOST_AUTO_TEST_CASE(exact_relation_test_1) {
+    Federation fed(3);
+    DBM dbm(3);
+
+    dbm.set(0, 0, bound_t::strict(-1));
+
+    auto relation1 = fed.exact_relation(dbm);
+    auto relation2 = dbm.exact_relation(fed);
+
+    BOOST_CHECK(relation1._superset);
+    BOOST_CHECK(not relation1._equal);
+    BOOST_CHECK(not relation1._subset);
+    BOOST_CHECK(not relation1._different);
+
+    BOOST_CHECK(not relation2._superset);
+    BOOST_CHECK(not relation2._equal);
+    BOOST_CHECK(relation2._subset);
+    BOOST_CHECK(not relation2._different);
+
+    BOOST_CHECK(fed.superset(dbm));
+    BOOST_CHECK(not fed.equal(dbm));
+    BOOST_CHECK(not fed.subset(dbm));
+
+    BOOST_CHECK(not dbm.superset(fed));
+    BOOST_CHECK(not dbm.equal(fed));
+    BOOST_CHECK(dbm.subset(fed));
+}
+
+BOOST_AUTO_TEST_CASE(exact_relation_test_2) {
+    DBM dbm(3);
+    auto fed = Federation();
+
+    auto relation1 = fed.exact_relation(dbm);
+    auto relation2 = dbm.exact_relation(fed);
+
+    BOOST_CHECK(not relation1._superset);
+    BOOST_CHECK(not relation1._equal);
+    BOOST_CHECK(relation1._subset);
+    BOOST_CHECK(not relation1._different);
+
+    BOOST_CHECK( relation2._superset);
+    BOOST_CHECK(not relation2._equal);
+    BOOST_CHECK(not relation2._subset);
+    BOOST_CHECK(not relation2._different);
+
+    BOOST_CHECK(not fed.superset(dbm));
+    BOOST_CHECK(not fed.equal(dbm));
+    BOOST_CHECK(fed.subset(dbm));
+
+    BOOST_CHECK(dbm.superset(fed));
+    BOOST_CHECK(not dbm.equal(fed));
+    BOOST_CHECK(not dbm.subset(fed));
+}
+
+BOOST_AUTO_TEST_CASE(exact_relation_test_3) {
+    Federation fed1(3);
+    auto fed2 = Federation();
+
+    auto relation1 = fed1.exact_relation(fed2);
+    auto relation2 = fed2.exact_relation(fed1);
+
+    BOOST_CHECK(relation1._superset);
+    BOOST_CHECK(not relation1._equal);
+    BOOST_CHECK(not relation1._subset);
+    BOOST_CHECK(not relation1._different);
+
+    BOOST_CHECK(not relation2._superset);
+    BOOST_CHECK(not relation2._equal);
+    BOOST_CHECK(relation2._subset);
+    BOOST_CHECK(not relation2._different);
+
+    BOOST_CHECK(fed1.superset(fed2));
+    BOOST_CHECK(not fed1.equal(fed2));
+    BOOST_CHECK(not fed1.subset(fed2));
+
+    BOOST_CHECK(not fed2.superset(fed1));
+    BOOST_CHECK(not fed2.equal(fed1));
+    BOOST_CHECK(fed2.subset(fed1));
+}
+
+BOOST_AUTO_TEST_CASE(exact_relation_test_4) {
+    auto fed = Federation::zero(3);
+    auto dbm = DBM::zero(3);
+    dbm.delay(2);
+
+    fed.add(dbm);
+
+    BOOST_CHECK(fed.exact_superset(dbm));
+}
+
+BOOST_AUTO_TEST_CASE(exact_relation_test_5) {
+    auto fed1 = Federation::zero(3),
+         fed2 = Federation::zero(3);
+    auto dbm = DBM::zero(3);
+
+    dbm.delay(2);
+
+    fed1.add(dbm);
+
+    BOOST_CHECK(fed1.exact_superset(fed2));
+    BOOST_CHECK(fed2.exact_subset(fed1));
+}
+
+BOOST_AUTO_TEST_CASE(exact_relation_test_6) {
+    auto fed1 = Federation::zero(3),
+         fed2 = Federation::zero(3);
+    auto dbm1 = DBM::unconstrained(3),
+         dbm2 = DBM::unconstrained(3),
+         dbm3 = DBM::unconstrained(3),
+         dbm4 = DBM::unconstrained(3);
+    
+    dbm1.restrict(clock_constraint_t::upper_non_strict(1, 10));
+    dbm2.restrict(clock_constraint_t::lower_strict(1, 10));
+
+    dbm3.restrict(clock_constraint_t::upper_non_strict(2, 10));
+    dbm4.restrict(clock_constraint_t::lower_strict(2, 10));
+    
+    // dbm1, dbm2, dbm3, dbm4 are disjunct but 1+2 and 3+4 they are equal to unconstrained
+
+    BOOST_CHECK(dbm1.relation(dbm2).different);
+    BOOST_CHECK(dbm1.relation(dbm3).different);
+    BOOST_CHECK(dbm1.relation(dbm4).different);
+    BOOST_CHECK(dbm2.relation(dbm3).different);
+    BOOST_CHECK(dbm2.relation(dbm4).different);
+    BOOST_CHECK(dbm3.relation(dbm4).different);
+
+    fed1.add(dbm1);
+    fed1.add(dbm2);
+    fed2.add(dbm3);
+    fed2.add(dbm4);
+
+    auto approx1 = fed1.relation(fed2);
+    auto approx2 = fed2.relation(fed1);
+    auto exact1 = fed1.exact_relation(fed2);
+    auto exact2 = fed2.exact_relation(fed1);
+
+    BOOST_CHECK(approx1._different && "If this fails, then perhaps the approximate relation is more precise");
+    BOOST_CHECK(approx2._different && "If this fails, then perhaps the approximate relation is more precise");
+
+    BOOST_CHECK(exact1._equal && exact2._equal);
+}
+
+BOOST_AUTO_TEST_CASE(exact_relation_test_7) {
+    auto fed1 = Federation::zero(3),
+         fed2 = Federation::zero(3);
+    auto dbm1 = DBM::unconstrained(3),
+         dbm2 = DBM::unconstrained(3);
+    
+    dbm1.restrict(clock_constraint_t::upper_non_strict(1, 10));
+    dbm2.restrict(clock_constraint_t::lower_strict(1, 10));
+
+    dbm1.restrict(clock_constraint_t::upper_non_strict(2, 5));
+    dbm2.restrict(clock_constraint_t::lower_strict(2, 5));
+
+    BOOST_CHECK(dbm1.relation(dbm2).different);
+    BOOST_CHECK(dbm2.relation(dbm1).different);
+
+    fed1.add(dbm1);
+    fed1.add(dbm2);
+    fed2.add(dbm1);
+    fed2.add(dbm2);
+
+    // auto approx1 = fed1.relation(fed2);
+    // auto approx2 = fed2.relation(fed1);
+    auto exact1 = fed1.exact_relation(fed2);
+    auto exact2 = fed2.exact_relation(fed1);
+
+    BOOST_CHECK(exact1._equal && exact2._equal);
+}
+
 BOOST_AUTO_TEST_CASE(intersects_test_1) {
     auto fed = Federation::zero(3);
     auto dbm = DBM::zero(3);

--- a/test/Federation_test.cpp
+++ b/test/Federation_test.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(at_test_1) {
     BOOST_CHECK_THROW(fed.at(1), base_error);
     BOOST_CHECK_THROW(fed.at(-1), base_error);
 
-    BOOST_CHECK(fed.at(0).equal<false>(DBM(3)));
+    BOOST_CHECK(fed.at(0).is_equal<false>(DBM(3)));
 }
 
 BOOST_AUTO_TEST_CASE(add_test_1) {
@@ -142,23 +142,23 @@ BOOST_AUTO_TEST_CASE(relation_test_1) {
     auto relation1 = fed.approx_relation(dbm);
     auto relation2 = dbm.approx_relation(fed);
 
-    BOOST_CHECK(relation1._superset);
-    BOOST_CHECK(not relation1._equal);
-    BOOST_CHECK(not relation1._subset);
-    BOOST_CHECK(not relation1._different);
+    BOOST_CHECK(relation1.is_superset());
+    BOOST_CHECK(not relation1.is_equal());
+    BOOST_CHECK(not relation1.is_subset());
+    BOOST_CHECK(not relation1.is_different());
 
-    BOOST_CHECK(not relation2._superset);
-    BOOST_CHECK(not relation2._equal);
-    BOOST_CHECK(relation2._subset);
-    BOOST_CHECK(not relation2._different);
+    BOOST_CHECK(not relation2.is_superset());
+    BOOST_CHECK(not relation2.is_equal());
+    BOOST_CHECK(relation2.is_subset());
+    BOOST_CHECK(not relation2.is_different());
 
-    BOOST_CHECK(fed.approx_superset(dbm));
-    BOOST_CHECK(not fed.approx_equal(dbm));
-    BOOST_CHECK(not fed.approx_subset(dbm));
+    BOOST_CHECK(fed.is_approx_superset(dbm));
+    BOOST_CHECK(not fed.is_approx_equal(dbm));
+    BOOST_CHECK(not fed.is_approx_subset(dbm));
 
-    BOOST_CHECK(not dbm.approx_superset(fed));
-    BOOST_CHECK(not dbm.approx_equal(fed));
-    BOOST_CHECK(dbm.approx_subset(fed));
+    BOOST_CHECK(not dbm.is_approx_superset(fed));
+    BOOST_CHECK(not dbm.is_approx_equal(fed));
+    BOOST_CHECK(dbm.is_approx_subset(fed));
 }
 
 BOOST_AUTO_TEST_CASE(relation_test_2) {
@@ -168,23 +168,23 @@ BOOST_AUTO_TEST_CASE(relation_test_2) {
     auto relation1 = fed.approx_relation(dbm);
     auto relation2 = dbm.approx_relation(fed);
 
-    BOOST_CHECK(not relation1._superset);
-    BOOST_CHECK(not relation1._equal);
-    BOOST_CHECK(relation1._subset);
-    BOOST_CHECK(not relation1._different);
+    BOOST_CHECK(not relation1.is_superset());
+    BOOST_CHECK(not relation1.is_equal());
+    BOOST_CHECK(relation1.is_subset());
+    BOOST_CHECK(not relation1.is_different());
 
-    BOOST_CHECK( relation2._superset);
-    BOOST_CHECK(not relation2._equal);
-    BOOST_CHECK(not relation2._subset);
-    BOOST_CHECK(not relation2._different);
+    BOOST_CHECK( relation2.is_superset());
+    BOOST_CHECK(not relation2.is_equal());
+    BOOST_CHECK(not relation2.is_subset());
+    BOOST_CHECK(not relation2.is_different());
 
-    BOOST_CHECK(not fed.approx_superset(dbm));
-    BOOST_CHECK(not fed.approx_equal(dbm));
-    BOOST_CHECK(fed.approx_subset(dbm));
+    BOOST_CHECK(not fed.is_approx_superset(dbm));
+    BOOST_CHECK(not fed.is_approx_equal(dbm));
+    BOOST_CHECK(fed.is_approx_subset(dbm));
 
-    BOOST_CHECK(dbm.approx_superset(fed));
-    BOOST_CHECK(not dbm.approx_equal(fed));
-    BOOST_CHECK(not dbm.approx_subset(fed));
+    BOOST_CHECK(dbm.is_approx_superset(fed));
+    BOOST_CHECK(not dbm.is_approx_equal(fed));
+    BOOST_CHECK(not dbm.is_approx_subset(fed));
 }
 
 BOOST_AUTO_TEST_CASE(relation_test_3) {
@@ -194,23 +194,23 @@ BOOST_AUTO_TEST_CASE(relation_test_3) {
     auto relation1 = fed1.approx_relation(fed2);
     auto relation2 = fed2.approx_relation(fed1);
 
-    BOOST_CHECK(relation1._superset);
-    BOOST_CHECK(not relation1._equal);
-    BOOST_CHECK(not relation1._subset);
-    BOOST_CHECK(not relation1._different);
+    BOOST_CHECK(relation1.is_superset());
+    BOOST_CHECK(not relation1.is_equal());
+    BOOST_CHECK(not relation1.is_subset());
+    BOOST_CHECK(not relation1.is_different());
 
-    BOOST_CHECK(not relation2._superset);
-    BOOST_CHECK(not relation2._equal);
-    BOOST_CHECK(relation2._subset);
-    BOOST_CHECK(not relation2._different);
+    BOOST_CHECK(not relation2.is_superset());
+    BOOST_CHECK(not relation2.is_equal());
+    BOOST_CHECK(relation2.is_subset());
+    BOOST_CHECK(not relation2.is_different());
 
-    BOOST_CHECK(fed1.approx_superset(fed2));
-    BOOST_CHECK(not fed1.approx_equal(fed2));
-    BOOST_CHECK(not fed1.approx_subset(fed2));
+    BOOST_CHECK(fed1.is_approx_superset(fed2));
+    BOOST_CHECK(not fed1.is_approx_equal(fed2));
+    BOOST_CHECK(not fed1.is_approx_subset(fed2));
 
-    BOOST_CHECK(not fed2.approx_superset(fed1));
-    BOOST_CHECK(not fed2.approx_equal(fed1));
-    BOOST_CHECK(fed2.approx_subset(fed1));
+    BOOST_CHECK(not fed2.is_approx_superset(fed1));
+    BOOST_CHECK(not fed2.is_approx_equal(fed1));
+    BOOST_CHECK(fed2.is_approx_subset(fed1));
 }
 
 BOOST_AUTO_TEST_CASE(relation_test_4) {
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(relation_test_4) {
 
     fed.add(dbm);
 
-    BOOST_CHECK(fed.approx_superset(dbm));
+    BOOST_CHECK(fed.is_approx_superset(dbm));
 }
 
 BOOST_AUTO_TEST_CASE(relation_test_5) {
@@ -232,8 +232,8 @@ BOOST_AUTO_TEST_CASE(relation_test_5) {
 
     fed1.add(dbm);
 
-    BOOST_CHECK(fed1.approx_superset(fed2));
-    BOOST_CHECK(fed2.approx_subset(fed1));
+    BOOST_CHECK(fed1.is_approx_superset(fed2));
+    BOOST_CHECK(fed2.is_approx_subset(fed1));
 }
 
 BOOST_AUTO_TEST_CASE(relation_test_6) {
@@ -248,8 +248,8 @@ BOOST_AUTO_TEST_CASE(relation_test_6) {
     dbm1.restrict(clock_constraint_t::upper_non_strict(2, 5));
     dbm2.restrict(clock_constraint_t::lower_strict(2, 5));
 
-    BOOST_CHECK(dbm1.relation(dbm2)._different);
-    BOOST_CHECK(dbm2.relation(dbm1)._different);
+    BOOST_CHECK(dbm1.relation(dbm2).is_different());
+    BOOST_CHECK(dbm2.relation(dbm1).is_different());
 
     fed1.add(dbm1);
     fed1.add(dbm2);
@@ -259,12 +259,12 @@ BOOST_AUTO_TEST_CASE(relation_test_6) {
     auto approx1 = fed1.approx_relation(fed2);
     auto approx2 = fed2.approx_relation(fed1);
 
-    BOOST_CHECK(fed1.approx_superset(dbm1));
-    BOOST_CHECK(fed1.approx_superset(dbm2));
-    BOOST_CHECK(fed2.approx_superset(dbm1));
-    BOOST_CHECK(fed2.approx_superset(dbm2));
-    BOOST_CHECK(approx1._superset);
-    BOOST_CHECK(approx2._superset);
+    BOOST_CHECK(fed1.is_approx_superset(dbm1));
+    BOOST_CHECK(fed1.is_approx_superset(dbm2));
+    BOOST_CHECK(fed2.is_approx_superset(dbm1));
+    BOOST_CHECK(fed2.is_approx_superset(dbm2));
+    BOOST_CHECK(approx1.is_superset());
+    BOOST_CHECK(approx2.is_superset());
 }
 
 BOOST_AUTO_TEST_CASE(exact_relation_test_1) {
@@ -276,23 +276,23 @@ BOOST_AUTO_TEST_CASE(exact_relation_test_1) {
     auto relation1 = fed.exact_relation(dbm);
     auto relation2 = dbm.exact_relation(fed);
 
-    BOOST_CHECK(relation1._superset);
-    BOOST_CHECK(not relation1._equal);
-    BOOST_CHECK(not relation1._subset);
-    BOOST_CHECK(not relation1._different);
+    BOOST_CHECK(relation1.is_superset());
+    BOOST_CHECK(not relation1.is_equal());
+    BOOST_CHECK(not relation1.is_subset());
+    BOOST_CHECK(not relation1.is_different());
 
-    BOOST_CHECK(not relation2._superset);
-    BOOST_CHECK(not relation2._equal);
-    BOOST_CHECK(relation2._subset);
-    BOOST_CHECK(not relation2._different);
+    BOOST_CHECK(not relation2.is_superset());
+    BOOST_CHECK(not relation2.is_equal());
+    BOOST_CHECK(relation2.is_subset());
+    BOOST_CHECK(not relation2.is_different());
 
-    BOOST_CHECK(fed.exact_superset(dbm));
-    BOOST_CHECK(not fed.exact_equal(dbm));
-    BOOST_CHECK(not fed.exact_subset(dbm));
+    BOOST_CHECK(fed.is_exact_superset(dbm));
+    BOOST_CHECK(not fed.is_exact_equal(dbm));
+    BOOST_CHECK(not fed.is_exact_subset(dbm));
 
-    BOOST_CHECK(not dbm.exact_superset(fed));
-    BOOST_CHECK(not dbm.exact_equal(fed));
-    BOOST_CHECK(dbm.exact_subset(fed));
+    BOOST_CHECK(not dbm.is_exact_superset(fed));
+    BOOST_CHECK(not dbm.is_exact_equal(fed));
+    BOOST_CHECK(dbm.is_exact_subset(fed));
 }
 
 BOOST_AUTO_TEST_CASE(exact_relation_test_2) {
@@ -302,23 +302,23 @@ BOOST_AUTO_TEST_CASE(exact_relation_test_2) {
     auto relation1 = fed.exact_relation(dbm);
     auto relation2 = dbm.exact_relation(fed);
 
-    BOOST_CHECK(not relation1._superset);
-    BOOST_CHECK(not relation1._equal);
-    BOOST_CHECK(relation1._subset);
-    BOOST_CHECK(not relation1._different);
+    BOOST_CHECK(not relation1.is_superset());
+    BOOST_CHECK(not relation1.is_equal());
+    BOOST_CHECK(relation1.is_subset());
+    BOOST_CHECK(not relation1.is_different());
 
-    BOOST_CHECK(relation2._superset);
-    BOOST_CHECK(not relation2._equal);
-    BOOST_CHECK(not relation2._subset);
-    BOOST_CHECK(not relation2._different);
+    BOOST_CHECK(relation2.is_superset());
+    BOOST_CHECK(not relation2.is_equal());
+    BOOST_CHECK(not relation2.is_subset());
+    BOOST_CHECK(not relation2.is_different());
 
-    BOOST_CHECK(not fed.exact_superset(dbm));
-    BOOST_CHECK(not fed.exact_equal(dbm));
-    BOOST_CHECK(fed.exact_subset(dbm));
+    BOOST_CHECK(not fed.is_exact_superset(dbm));
+    BOOST_CHECK(not fed.is_exact_equal(dbm));
+    BOOST_CHECK(fed.is_exact_subset(dbm));
 
-    BOOST_CHECK(dbm.exact_superset(fed));
-    BOOST_CHECK(not dbm.exact_equal(fed));
-    BOOST_CHECK(not dbm.exact_subset(fed));
+    BOOST_CHECK(dbm.is_exact_superset(fed));
+    BOOST_CHECK(not dbm.is_exact_equal(fed));
+    BOOST_CHECK(not dbm.is_exact_subset(fed));
 }
 
 BOOST_AUTO_TEST_CASE(exact_relation_test_3) {
@@ -328,23 +328,23 @@ BOOST_AUTO_TEST_CASE(exact_relation_test_3) {
     auto relation1 = fed1.exact_relation(fed2);
     auto relation2 = fed2.exact_relation(fed1);
 
-    BOOST_CHECK(relation1._superset);
-    BOOST_CHECK(not relation1._equal);
-    BOOST_CHECK(not relation1._subset);
-    BOOST_CHECK(not relation1._different);
+    BOOST_CHECK(relation1.is_superset());
+    BOOST_CHECK(not relation1.is_equal());
+    BOOST_CHECK(not relation1.is_subset());
+    BOOST_CHECK(not relation1.is_different());
 
-    BOOST_CHECK(not relation2._superset);
-    BOOST_CHECK(not relation2._equal);
-    BOOST_CHECK(relation2._subset);
-    BOOST_CHECK(not relation2._different);
+    BOOST_CHECK(not relation2.is_superset());
+    BOOST_CHECK(not relation2.is_equal());
+    BOOST_CHECK(relation2.is_subset());
+    BOOST_CHECK(not relation2.is_different());
 
-    BOOST_CHECK(fed1.exact_superset(fed2));
-    BOOST_CHECK(not fed1.exact_equal(fed2));
-    BOOST_CHECK(not fed1.exact_subset(fed2));
+    BOOST_CHECK(fed1.is_exact_superset(fed2));
+    BOOST_CHECK(not fed1.is_exact_equal(fed2));
+    BOOST_CHECK(not fed1.is_exact_subset(fed2));
 
-    BOOST_CHECK(not fed2.exact_superset(fed1));
-    BOOST_CHECK(not fed2.exact_equal(fed1));
-    BOOST_CHECK(fed2.exact_subset(fed1));
+    BOOST_CHECK(not fed2.is_exact_superset(fed1));
+    BOOST_CHECK(not fed2.is_exact_equal(fed1));
+    BOOST_CHECK(fed2.is_exact_subset(fed1));
 }
 
 BOOST_AUTO_TEST_CASE(exact_relation_test_4) {
@@ -354,7 +354,7 @@ BOOST_AUTO_TEST_CASE(exact_relation_test_4) {
 
     fed.add(dbm);
 
-    BOOST_CHECK(fed.exact_superset(dbm));
+    BOOST_CHECK(fed.is_exact_superset(dbm));
 }
 
 BOOST_AUTO_TEST_CASE(exact_relation_test_5) {
@@ -366,8 +366,8 @@ BOOST_AUTO_TEST_CASE(exact_relation_test_5) {
 
     fed1.add(dbm);
 
-    BOOST_CHECK(fed1.exact_superset(fed2));
-    BOOST_CHECK(fed2.exact_subset(fed1));
+    BOOST_CHECK(fed1.is_exact_superset(fed2));
+    BOOST_CHECK(fed2.is_exact_subset(fed1));
 }
 
 BOOST_AUTO_TEST_CASE(exact_relation_test_6) {
@@ -403,10 +403,10 @@ BOOST_AUTO_TEST_CASE(exact_relation_test_6) {
     auto exact1 = fed1.exact_relation(fed2);
     auto exact2 = fed2.exact_relation(fed1);
 
-    // BOOST_CHECK(approx1._different && "If this fails, then perhaps the approximate relation is more precise");
-    // BOOST_CHECK(approx2._different && "If this fails, then perhaps the approximate relation is more precise");
+    // BOOST_CHECK(approx1.is_different() && "If this fails, then perhaps the approximate relation is more precise");
+    // BOOST_CHECK(approx2.is_different() && "If this fails, then perhaps the approximate relation is more precise");
 
-    BOOST_CHECK(exact1._equal && exact2._equal);
+    BOOST_CHECK(exact1.is_equal() && exact2.is_equal());
 }
 
 BOOST_AUTO_TEST_CASE(exact_relation_test_7) {
@@ -434,7 +434,7 @@ BOOST_AUTO_TEST_CASE(exact_relation_test_7) {
     auto exact1 = fed1.exact_relation(fed2);
     auto exact2 = fed2.exact_relation(fed1);
 
-    BOOST_CHECK(exact1._equal && exact2._equal);
+    BOOST_CHECK(exact1.is_equal() && exact2.is_equal());
 }
 
 BOOST_AUTO_TEST_CASE(intersects_test_1) {
@@ -565,7 +565,7 @@ BOOST_AUTO_TEST_CASE(restrict_test_2) {
 
     fed1.restrict({});
 
-    BOOST_CHECK(fed1.equal(fed2));
+    BOOST_CHECK(fed1.is_equal(fed2));
 }
 
 BOOST_AUTO_TEST_CASE(intersection_test_1) {
@@ -574,7 +574,7 @@ BOOST_AUTO_TEST_CASE(intersection_test_1) {
 
     fed.intersection(dbm);
 
-    BOOST_CHECK(fed.equal(dbm));
+    BOOST_CHECK(fed.is_equal(dbm));
 }
 
 BOOST_AUTO_TEST_CASE(intersection_test_2) {
@@ -584,7 +584,7 @@ BOOST_AUTO_TEST_CASE(intersection_test_2) {
     dbm.restrict(0, 1, bound_t::strict(-1));
     fed.intersection(dbm);
 
-    BOOST_CHECK(fed.equal(dbm));
+    BOOST_CHECK(fed.is_equal(dbm));
     BOOST_CHECK(fed.is_empty());
 }
 
@@ -603,7 +603,7 @@ BOOST_AUTO_TEST_CASE(intersection_test_3) {
 
     fed.intersection(dbm2);
 
-    BOOST_CHECK(not fed.equal(dbm2));
+    BOOST_CHECK(not fed.is_equal(dbm2));
     BOOST_CHECK(not fed.is_empty());
     BOOST_CHECK(fed.size() == 2);
     BOOST_CHECK(fed.satisfies(1, 0, bound_t::strict(2)));
@@ -694,7 +694,7 @@ BOOST_AUTO_TEST_CASE(zero_test_1) {
     auto fed = Federation();
     fed.add(DBM::zero(dim));
 
-    BOOST_CHECK(fed.equal(Federation::zero(dim)));
+    BOOST_CHECK(fed.is_equal(Federation::zero(dim)));
 }
 
 BOOST_AUTO_TEST_CASE(unconstrained_test_1) {
@@ -702,5 +702,5 @@ BOOST_AUTO_TEST_CASE(unconstrained_test_1) {
     auto fed = Federation();
     fed.add(DBM::unconstrained(dim));
 
-    BOOST_CHECK(fed.equal(Federation::unconstrained(dim)));
+    BOOST_CHECK(fed.is_equal(Federation::unconstrained(dim)));
 }

--- a/test/Federation_test.cpp
+++ b/test/Federation_test.cpp
@@ -268,6 +268,22 @@ BOOST_AUTO_TEST_CASE(relation_test_6) {
     BOOST_CHECK(approx2.is_equal());
 }
 
+BOOST_AUTO_TEST_CASE(relation_test_7) {
+    auto fed1 = Federation::unconstrained(3),
+         fed2 = Federation::zero(3);
+    auto dbm = DBM::unconstrained(3);
+
+    dbm.restrict(clock_constraint_t::upper_strict(1, 2));
+
+    fed2.add(dbm);
+
+    // should terminate faster
+    BOOST_CHECK(fed1.is_superset(fed2));
+
+    // Does not terminate faster
+    BOOST_CHECK(fed2.is_subset(fed1));
+}
+
 BOOST_AUTO_TEST_CASE(exact_relation_test_1) {
     Federation fed(3);
     DBM dbm(3);

--- a/test/Federation_test.cpp
+++ b/test/Federation_test.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(at_test_1) {
     BOOST_CHECK_THROW(fed.at(1), base_error);
     BOOST_CHECK_THROW(fed.at(-1), base_error);
 
-    BOOST_CHECK(fed.at(0).equal(DBM(3)));
+    BOOST_CHECK(fed.at(0).equal<false>(DBM(3)));
 }
 
 BOOST_AUTO_TEST_CASE(add_test_1) {
@@ -139,8 +139,8 @@ BOOST_AUTO_TEST_CASE(relation_test_1) {
 
     dbm.set(0, 0, bound_t::strict(-1));
 
-    auto relation1 = fed.relation(dbm);
-    auto relation2 = dbm.relation(fed);
+    auto relation1 = fed.approx_relation(dbm);
+    auto relation2 = dbm.approx_relation(fed);
 
     BOOST_CHECK(relation1._superset);
     BOOST_CHECK(not relation1._equal);
@@ -152,21 +152,21 @@ BOOST_AUTO_TEST_CASE(relation_test_1) {
     BOOST_CHECK(relation2._subset);
     BOOST_CHECK(not relation2._different);
 
-    BOOST_CHECK(fed.superset(dbm));
-    BOOST_CHECK(not fed.equal(dbm));
-    BOOST_CHECK(not fed.subset(dbm));
+    BOOST_CHECK(fed.approx_superset(dbm));
+    BOOST_CHECK(not fed.approx_equal(dbm));
+    BOOST_CHECK(not fed.approx_subset(dbm));
 
-    BOOST_CHECK(not dbm.superset(fed));
-    BOOST_CHECK(not dbm.equal(fed));
-    BOOST_CHECK(dbm.subset(fed));
+    BOOST_CHECK(not dbm.approx_superset(fed));
+    BOOST_CHECK(not dbm.approx_equal(fed));
+    BOOST_CHECK(dbm.approx_subset(fed));
 }
 
 BOOST_AUTO_TEST_CASE(relation_test_2) {
     DBM dbm(3);
     auto fed = Federation();
 
-    auto relation1 = fed.relation(dbm);
-    auto relation2 = dbm.relation(fed);
+    auto relation1 = fed.approx_relation(dbm);
+    auto relation2 = dbm.approx_relation(fed);
 
     BOOST_CHECK(not relation1._superset);
     BOOST_CHECK(not relation1._equal);
@@ -178,21 +178,21 @@ BOOST_AUTO_TEST_CASE(relation_test_2) {
     BOOST_CHECK(not relation2._subset);
     BOOST_CHECK(not relation2._different);
 
-    BOOST_CHECK(not fed.superset(dbm));
-    BOOST_CHECK(not fed.equal(dbm));
-    BOOST_CHECK(fed.subset(dbm));
+    BOOST_CHECK(not fed.approx_superset(dbm));
+    BOOST_CHECK(not fed.approx_equal(dbm));
+    BOOST_CHECK(fed.approx_subset(dbm));
 
-    BOOST_CHECK(dbm.superset(fed));
-    BOOST_CHECK(not dbm.equal(fed));
-    BOOST_CHECK(not dbm.subset(fed));
+    BOOST_CHECK(dbm.approx_superset(fed));
+    BOOST_CHECK(not dbm.approx_equal(fed));
+    BOOST_CHECK(not dbm.approx_subset(fed));
 }
 
 BOOST_AUTO_TEST_CASE(relation_test_3) {
     Federation fed1(3);
     auto fed2 = Federation();
 
-    auto relation1 = fed1.relation(fed2);
-    auto relation2 = fed2.relation(fed1);
+    auto relation1 = fed1.approx_relation(fed2);
+    auto relation2 = fed2.approx_relation(fed1);
 
     BOOST_CHECK(relation1._superset);
     BOOST_CHECK(not relation1._equal);
@@ -204,13 +204,13 @@ BOOST_AUTO_TEST_CASE(relation_test_3) {
     BOOST_CHECK(relation2._subset);
     BOOST_CHECK(not relation2._different);
 
-    BOOST_CHECK(fed1.superset(fed2));
-    BOOST_CHECK(not fed1.equal(fed2));
-    BOOST_CHECK(not fed1.subset(fed2));
+    BOOST_CHECK(fed1.approx_superset(fed2));
+    BOOST_CHECK(not fed1.approx_equal(fed2));
+    BOOST_CHECK(not fed1.approx_subset(fed2));
 
-    BOOST_CHECK(not fed2.superset(fed1));
-    BOOST_CHECK(not fed2.equal(fed1));
-    BOOST_CHECK(fed2.subset(fed1));
+    BOOST_CHECK(not fed2.approx_superset(fed1));
+    BOOST_CHECK(not fed2.approx_equal(fed1));
+    BOOST_CHECK(fed2.approx_subset(fed1));
 }
 
 BOOST_AUTO_TEST_CASE(relation_test_4) {
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(relation_test_4) {
 
     fed.add(dbm);
 
-    BOOST_CHECK(fed.superset(dbm));
+    BOOST_CHECK(fed.approx_superset(dbm));
 }
 
 BOOST_AUTO_TEST_CASE(relation_test_5) {
@@ -232,8 +232,8 @@ BOOST_AUTO_TEST_CASE(relation_test_5) {
 
     fed1.add(dbm);
 
-    BOOST_CHECK(fed1.superset(fed2));
-    BOOST_CHECK(fed2.subset(fed1));
+    BOOST_CHECK(fed1.approx_superset(fed2));
+    BOOST_CHECK(fed2.approx_subset(fed1));
 }
 
 BOOST_AUTO_TEST_CASE(relation_test_6) {
@@ -248,21 +248,21 @@ BOOST_AUTO_TEST_CASE(relation_test_6) {
     dbm1.restrict(clock_constraint_t::upper_non_strict(2, 5));
     dbm2.restrict(clock_constraint_t::lower_strict(2, 5));
 
-    BOOST_CHECK(dbm1.relation(dbm2).different);
-    BOOST_CHECK(dbm2.relation(dbm1).different);
+    BOOST_CHECK(dbm1.relation(dbm2)._different);
+    BOOST_CHECK(dbm2.relation(dbm1)._different);
 
     fed1.add(dbm1);
     fed1.add(dbm2);
     fed2.add(dbm1);
     fed2.add(dbm2);
 
-    auto approx1 = fed1.relation(fed2);
-    auto approx2 = fed2.relation(fed1);
+    auto approx1 = fed1.approx_relation(fed2);
+    auto approx2 = fed2.approx_relation(fed1);
 
-    BOOST_CHECK(fed1.superset(dbm1));
-    BOOST_CHECK(fed1.superset(dbm2));
-    BOOST_CHECK(fed2.superset(dbm1));
-    BOOST_CHECK(fed2.superset(dbm2));
+    BOOST_CHECK(fed1.approx_superset(dbm1));
+    BOOST_CHECK(fed1.approx_superset(dbm2));
+    BOOST_CHECK(fed2.approx_superset(dbm1));
+    BOOST_CHECK(fed2.approx_superset(dbm2));
     BOOST_CHECK(approx1._superset);
     BOOST_CHECK(approx2._superset);
 }
@@ -286,13 +286,13 @@ BOOST_AUTO_TEST_CASE(exact_relation_test_1) {
     BOOST_CHECK(relation2._subset);
     BOOST_CHECK(not relation2._different);
 
-    BOOST_CHECK(fed.superset(dbm));
-    BOOST_CHECK(not fed.equal(dbm));
-    BOOST_CHECK(not fed.subset(dbm));
+    BOOST_CHECK(fed.exact_superset(dbm));
+    BOOST_CHECK(not fed.exact_equal(dbm));
+    BOOST_CHECK(not fed.exact_subset(dbm));
 
-    BOOST_CHECK(not dbm.superset(fed));
-    BOOST_CHECK(not dbm.equal(fed));
-    BOOST_CHECK(dbm.subset(fed));
+    BOOST_CHECK(not dbm.exact_superset(fed));
+    BOOST_CHECK(not dbm.exact_equal(fed));
+    BOOST_CHECK(dbm.exact_subset(fed));
 }
 
 BOOST_AUTO_TEST_CASE(exact_relation_test_2) {
@@ -307,18 +307,18 @@ BOOST_AUTO_TEST_CASE(exact_relation_test_2) {
     BOOST_CHECK(relation1._subset);
     BOOST_CHECK(not relation1._different);
 
-    BOOST_CHECK( relation2._superset);
+    BOOST_CHECK(relation2._superset);
     BOOST_CHECK(not relation2._equal);
     BOOST_CHECK(not relation2._subset);
     BOOST_CHECK(not relation2._different);
 
-    BOOST_CHECK(not fed.superset(dbm));
-    BOOST_CHECK(not fed.equal(dbm));
-    BOOST_CHECK(fed.subset(dbm));
+    BOOST_CHECK(not fed.exact_superset(dbm));
+    BOOST_CHECK(not fed.exact_equal(dbm));
+    BOOST_CHECK(fed.exact_subset(dbm));
 
-    BOOST_CHECK(dbm.superset(fed));
-    BOOST_CHECK(not dbm.equal(fed));
-    BOOST_CHECK(not dbm.subset(fed));
+    BOOST_CHECK(dbm.exact_superset(fed));
+    BOOST_CHECK(not dbm.exact_equal(fed));
+    BOOST_CHECK(not dbm.exact_subset(fed));
 }
 
 BOOST_AUTO_TEST_CASE(exact_relation_test_3) {
@@ -338,13 +338,13 @@ BOOST_AUTO_TEST_CASE(exact_relation_test_3) {
     BOOST_CHECK(relation2._subset);
     BOOST_CHECK(not relation2._different);
 
-    BOOST_CHECK(fed1.superset(fed2));
-    BOOST_CHECK(not fed1.equal(fed2));
-    BOOST_CHECK(not fed1.subset(fed2));
+    BOOST_CHECK(fed1.exact_superset(fed2));
+    BOOST_CHECK(not fed1.exact_equal(fed2));
+    BOOST_CHECK(not fed1.exact_subset(fed2));
 
-    BOOST_CHECK(not fed2.superset(fed1));
-    BOOST_CHECK(not fed2.equal(fed1));
-    BOOST_CHECK(fed2.subset(fed1));
+    BOOST_CHECK(not fed2.exact_superset(fed1));
+    BOOST_CHECK(not fed2.exact_equal(fed1));
+    BOOST_CHECK(fed2.exact_subset(fed1));
 }
 
 BOOST_AUTO_TEST_CASE(exact_relation_test_4) {
@@ -398,13 +398,13 @@ BOOST_AUTO_TEST_CASE(exact_relation_test_6) {
     fed2.add(dbm3);
     fed2.add(dbm4);
 
-    auto approx1 = fed1.relation(fed2);
-    auto approx2 = fed2.relation(fed1);
+    // auto approx1 = fed1.approx_relation(fed2);
+    // auto approx2 = fed2.approx_relation(fed1);
     auto exact1 = fed1.exact_relation(fed2);
     auto exact2 = fed2.exact_relation(fed1);
 
-    BOOST_CHECK(approx1._different && "If this fails, then perhaps the approximate relation is more precise");
-    BOOST_CHECK(approx2._different && "If this fails, then perhaps the approximate relation is more precise");
+    // BOOST_CHECK(approx1._different && "If this fails, then perhaps the approximate relation is more precise");
+    // BOOST_CHECK(approx2._different && "If this fails, then perhaps the approximate relation is more precise");
 
     BOOST_CHECK(exact1._equal && exact2._equal);
 }
@@ -429,8 +429,8 @@ BOOST_AUTO_TEST_CASE(exact_relation_test_7) {
     fed2.add(dbm1);
     fed2.add(dbm2);
 
-    // auto approx1 = fed1.relation(fed2);
-    // auto approx2 = fed2.relation(fed1);
+    // auto approx1 = fed1.relation<false>(fed2);
+    // auto approx2 = fed2.relation<false>(fed1);
     auto exact1 = fed1.exact_relation(fed2);
     auto exact2 = fed2.exact_relation(fed1);
 


### PR DESCRIPTION
Implemented an exact relation, as well as updated the approximate relation. The implementation is done in a template method with a bunch of alias methods added in for good measure. The DBM - DBM relation is always exact, so this has no template method.
Also updated `relation_t` such that subset/superset no longer overlaps with equal.
The relation methods now use "is_" prefix as well.