### PR TITLE
Smarter bound operators

### DIFF
--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -81,17 +81,17 @@ namespace pardibaal {
         return false;
     }
 
-    bool DBM::satisfies(dim_t x, dim_t y, bound_t g) const {
+    bool DBM::is_satisfying(dim_t x, dim_t y, bound_t g) const {
         return bound_t::zero() <= (this->_bounds_table.at(y, x) + g);
     }
 
-    bool DBM::satisfies(const clock_constraint_t& constraint) const {
-        return satisfies(constraint._i, constraint._j, constraint._bound);
+    bool DBM::is_satisfying(const clock_constraint_t& constraint) const {
+        return is_satisfying(constraint._i, constraint._j, constraint._bound);
     }
 
-    bool DBM::satisfies(const std::vector<clock_constraint_t>& constraints) const {
+    bool DBM::is_satisfying(const std::vector<clock_constraint_t>& constraints) const {
         return std::all_of(constraints.begin(), constraints.end(), [this](const clock_constraint_t& c) {
-            return this->satisfies(c);
+            return this->is_satisfying(c);
         });
     }
 
@@ -163,7 +163,7 @@ namespace pardibaal {
     template bool DBM::is_different<true>(const Federation& fed) const;
     template bool DBM::is_different<false>(const Federation& fed) const;
 
-    bool DBM::intersects(const DBM &dbm) const {
+    bool DBM::is_intersecting(const DBM &dbm) const {
 #ifndef NEXCEPTIONS
         if (dbm.dimension() != dimension())
             throw(base_error("ERROR: Cannot measure intersection of two dbms with different dimensions. ",
@@ -189,7 +189,7 @@ namespace pardibaal {
         return true;
     }
 
-    bool DBM::intersects(const Federation& fed) const {
+    bool DBM::is_intersecting(const Federation& fed) const {
         return fed.intersects(*this);
     }
 

--- a/src/pardibaal/DBM.h
+++ b/src/pardibaal/DBM.h
@@ -75,9 +75,9 @@ namespace pardibaal {
 
         [[nodiscard]] bool is_empty() const;
 
-        [[nodiscard]] bool satisfies(dim_t x, dim_t y, bound_t g) const;
-        [[nodiscard]] bool satisfies(const clock_constraint_t& constraint) const;
-        [[nodiscard]] bool satisfies(const std::vector<clock_constraint_t>& constraints) const;
+        [[nodiscard]] bool is_satisfying(dim_t x, dim_t y, bound_t g) const;
+        [[nodiscard]] bool is_satisfying(const clock_constraint_t& constraint) const;
+        [[nodiscard]] bool is_satisfying(const std::vector<clock_constraint_t>& constraints) const;
 
         /**
          * Relation between this dbm and another dbm.
@@ -135,13 +135,13 @@ namespace pardibaal {
          * Checks if two DBMs intersect ie. if the intersection is non-empty
          * @return true if this intersects with dbm
          */
-        [[nodiscard]] bool intersects(const DBM& dbm) const;
+        [[nodiscard]] bool is_intersecting(const DBM& dbm) const;
 
         /**
          * Checks if a DBM intersect with a federation ie. if the intersection is non-empty
          * @return true if this intersects with fed
          */
-        [[nodiscard]] bool intersects(const Federation& fed) const;
+        [[nodiscard]] bool is_intersecting(const Federation& fed) const;
 
         /** Is bounded
          * Checks whether all upper bounds are infinite

--- a/src/pardibaal/Federation.cpp
+++ b/src/pardibaal/Federation.cpp
@@ -125,21 +125,21 @@ namespace pardibaal {
         return true;
     }
 
-    bool Federation::satisfies(dim_t x, dim_t y, bound_t g) const {
+    bool Federation::is_satisfying(dim_t x, dim_t y, bound_t g) const {
         for (const auto& dbm : zones) {
-            if (dbm.satisfies(x, y, g))
+            if (dbm.is_satisfying(x, y, g))
                 return true;
         }
         return false;
     }
 
-    bool Federation::satisfies(const clock_constraint_t& constraint) const {
-        return satisfies(constraint._i, constraint._j, constraint._bound);
+    bool Federation::is_satisfying(const clock_constraint_t& constraint) const {
+        return is_satisfying(constraint._i, constraint._j, constraint._bound);
     }
 
-    bool Federation::satisfies(const std::vector<clock_constraint_t>& constraints) const {
+    bool Federation::is_satisfying(const std::vector<clock_constraint_t>& constraints) const {
         for (const auto& c : constraints)
-            if (not satisfies(c._i, c._j, c._bound))
+            if (not is_satisfying(c._i, c._j, c._bound))
                 return false;
 
         return true;
@@ -299,7 +299,7 @@ namespace pardibaal {
     
 
     bool Federation::intersects(const DBM& dbm) const {
-        return std::any_of(this->begin(), this->end(), [&dbm](const DBM& z){return z.intersects(dbm);});
+        return std::any_of(this->begin(), this->end(), [&dbm](const DBM& z){return z.is_intersecting(dbm);});
     }
 
     bool Federation::intersects(const Federation& fed) const {

--- a/src/pardibaal/Federation.h
+++ b/src/pardibaal/Federation.h
@@ -120,10 +120,10 @@ namespace pardibaal {
          * @param g The bound (value and strictness) that is checked for
          * @return True if any of the zones satisfy the bound
          */
-        [[nodiscard]] bool satisfies(dim_t x, dim_t y, bound_t g) const;
+        [[nodiscard]] bool is_satisfying(dim_t x, dim_t y, bound_t g) const;
 
-        [[nodiscard]] bool satisfies(const clock_constraint_t& constraint) const;
-        [[nodiscard]] bool satisfies(const std::vector<clock_constraint_t>& constraints) const;
+        [[nodiscard]] bool is_satisfying(const clock_constraint_t& constraint) const;
+        [[nodiscard]] bool is_satisfying(const std::vector<clock_constraint_t>& constraints) const;
 
         /**
          * Relation between this and a dbm.

--- a/src/pardibaal/bound_t.cpp
+++ b/src/pardibaal/bound_t.cpp
@@ -67,15 +67,21 @@ namespace pardibaal {
     }
 
     bound_t bound_t::operator+(val_t rhs) const {
-        return bound_t(this->get_bound() + rhs, this->is_strict());
+        if (not this->is_inf())
+            return bound_t(this->get_bound() + rhs, this->is_strict());
+        return *this;
     }
 
     bound_t bound_t::operator-(val_t rhs) const {
-        return bound_t(this->get_bound() - rhs, this->is_strict());
+        if (not this->is_inf())
+            return bound_t(this->get_bound() - rhs, this->is_strict());
+        return *this;
     }
 
     bound_t bound_t::operator*(val_t rhs) const {
-        return bound_t(this->get_bound() * rhs, this->is_strict());
+        if (not this->is_inf())
+            return bound_t(this->get_bound() * rhs, this->is_strict());
+        return *this;
     }
 
     bool bound_t::operator<(bound_t rhs) const {

--- a/src/pardibaal/bound_t.h
+++ b/src/pardibaal/bound_t.h
@@ -80,10 +80,10 @@ namespace pardibaal {
 
         friend std::ostream& operator<<(std::ostream& out, const bound_t& bound);
 
-        [[nodiscard]] static bool lt(bound_t lhs, bound_t rhs) {return lhs < rhs;}
-        [[nodiscard]] static bool le(bound_t lhs, bound_t rhs) {return lhs <= rhs;}
-        [[nodiscard]] static bool gt(bound_t lhs, bound_t rhs) {return lhs > rhs;}
-        [[nodiscard]] static bool ge(bound_t lhs, bound_t rhs) {return lhs >= rhs;}
+        [[nodiscard]] static bool is_lt(bound_t lhs, bound_t rhs) {return lhs < rhs;}
+        [[nodiscard]] static bool is_le(bound_t lhs, bound_t rhs) {return lhs <= rhs;}
+        [[nodiscard]] static bool is_gt(bound_t lhs, bound_t rhs) {return lhs > rhs;}
+        [[nodiscard]] static bool is_ge(bound_t lhs, bound_t rhs) {return lhs >= rhs;}
     };
 
     [[nodiscard]] bound_t operator+(val_t val, bound_t bound);

--- a/test/DBM_test.cpp
+++ b/test/DBM_test.cpp
@@ -83,6 +83,28 @@ BOOST_AUTO_TEST_CASE(bounded_future_test_2) {
     BOOST_CHECK(Z.is_equal(D));
 }
 
+BOOST_AUTO_TEST_CASE(bounded_future_test_3) {
+    DBM D(10);
+
+    D.free(2);
+    D.future(5);
+
+    for (dim_t i = 0; i < 10; i++)
+        for (dim_t j = 0; j < 10; j++) {               
+            if (j == 0 && i != 0) {
+                if (i == 2)
+                    BOOST_CHECK(D.at(i, j) == bound_t::inf() && D.at(i,j).get_bound() == 0);
+                else
+                    BOOST_CHECK(D.at(i, j) == bound_t::non_strict(5));
+            } else {
+                if (i == 2 && j != 2)
+                    BOOST_CHECK(D.at(i, j) == bound_t::inf() && D.at(i, j).get_bound() == 0);
+                else
+                    BOOST_CHECK(D.at(i, j) == bound_t::zero());
+            }
+        }
+}
+
 BOOST_AUTO_TEST_CASE(delay_test_1) {
     DBM D(10);
 

--- a/test/DBM_test.cpp
+++ b/test/DBM_test.cpp
@@ -267,12 +267,12 @@ BOOST_AUTO_TEST_CASE(trace_test_1) {
     BOOST_CHECK(D.at(0, z) == bound_t::zero());
 
     // To goal
-    BOOST_CHECK(D.satisfies(x, 0, bound_t::non_strict(2)));
-    BOOST_CHECK(D.satisfies(0, x, bound_t::non_strict(-2)));
-    BOOST_CHECK(D.satisfies(y, 0, bound_t::non_strict(4)));
-    BOOST_CHECK(D.satisfies(0, y, bound_t::non_strict(-4)));
-    BOOST_CHECK(D.satisfies(z, 0, bound_t::non_strict(3)));
-    BOOST_CHECK(D.satisfies(0, z, bound_t::non_strict(-3)));
+    BOOST_CHECK(D.is_satisfying(x, 0, bound_t::non_strict(2)));
+    BOOST_CHECK(D.is_satisfying(0, x, bound_t::non_strict(-2)));
+    BOOST_CHECK(D.is_satisfying(y, 0, bound_t::non_strict(4)));
+    BOOST_CHECK(D.is_satisfying(0, y, bound_t::non_strict(-4)));
+    BOOST_CHECK(D.is_satisfying(z, 0, bound_t::non_strict(3)));
+    BOOST_CHECK(D.is_satisfying(0, z, bound_t::non_strict(-3)));
 
     D.restrict(x, 0, bound_t::non_strict(2));
     D.restrict(0, x, bound_t::non_strict(-2));
@@ -432,17 +432,17 @@ BOOST_AUTO_TEST_CASE(resize_test_1) {
     std::vector<dim_t> indir = D.resize(src, dst);
 
 
-    BOOST_CHECK(D.satisfies(1, 0, bound_t::zero()));
-    BOOST_CHECK(D.satisfies(0, 1, bound_t::zero()));
+    BOOST_CHECK(D.is_satisfying(1, 0, bound_t::zero()));
+    BOOST_CHECK(D.is_satisfying(0, 1, bound_t::zero()));
 
-    BOOST_CHECK(D.satisfies(2, 0, bound_t::non_strict(1)));
-    BOOST_CHECK(D.satisfies(0, 2, bound_t::non_strict(1)));
+    BOOST_CHECK(D.is_satisfying(2, 0, bound_t::non_strict(1)));
+    BOOST_CHECK(D.is_satisfying(0, 2, bound_t::non_strict(1)));
 
-    BOOST_CHECK(D.satisfies(3, 0, bound_t::inf()));
-    BOOST_CHECK(D.satisfies(0, 3, bound_t::zero()));
+    BOOST_CHECK(D.is_satisfying(3, 0, bound_t::inf()));
+    BOOST_CHECK(D.is_satisfying(0, 3, bound_t::zero()));
 
-    BOOST_CHECK(D.satisfies(4, 0, bound_t::non_strict(4)));
-    BOOST_CHECK(D.satisfies(0, 4, bound_t::non_strict(4)));
+    BOOST_CHECK(D.is_satisfying(4, 0, bound_t::non_strict(4)));
+    BOOST_CHECK(D.is_satisfying(0, 4, bound_t::non_strict(4)));
 }
 
 BOOST_AUTO_TEST_CASE(resize_test_2) {
@@ -470,14 +470,14 @@ BOOST_AUTO_TEST_CASE(reorder_test_1) {
 
     BOOST_CHECK(D.dimension() == 4);
 
-    BOOST_CHECK(D.satisfies(1, 0, bound_t::non_strict(3)));
-    BOOST_CHECK(D.satisfies(0, 1, bound_t::non_strict(3)));
+    BOOST_CHECK(D.is_satisfying(1, 0, bound_t::non_strict(3)));
+    BOOST_CHECK(D.is_satisfying(0, 1, bound_t::non_strict(3)));
 
-    BOOST_CHECK(D.satisfies(2, 0, bound_t::zero()));
-    BOOST_CHECK(D.satisfies(0, 2, bound_t::zero()));
+    BOOST_CHECK(D.is_satisfying(2, 0, bound_t::zero()));
+    BOOST_CHECK(D.is_satisfying(0, 2, bound_t::zero()));
 
-    BOOST_CHECK(D.satisfies(3, 0, bound_t::inf()));
-    BOOST_CHECK(D.satisfies(0, 3, bound_t::zero()));
+    BOOST_CHECK(D.is_satisfying(3, 0, bound_t::inf()));
+    BOOST_CHECK(D.is_satisfying(0, 3, bound_t::zero()));
 }
 
 BOOST_AUTO_TEST_CASE(reorder_test_2) {
@@ -811,13 +811,13 @@ BOOST_AUTO_TEST_CASE(intersection_test_2) {
     dbm1.restrict(0, 1, bound_t::strict(-2));
     dbm2.future();
 
-    BOOST_CHECK(dbm1.intersects(dbm2));
+    BOOST_CHECK(dbm1.is_intersecting(dbm2));
 
     dbm1.intersection(dbm2);
 
-    BOOST_CHECK(dbm1.satisfies(0, 1, bound_t::strict(-2)));
-    BOOST_CHECK(not dbm1.satisfies(1, 0, bound_t::non_strict(-2)));
-    BOOST_CHECK(dbm1.satisfies(1, 0, bound_t::inf()));
+    BOOST_CHECK(dbm1.is_satisfying(0, 1, bound_t::strict(-2)));
+    BOOST_CHECK(not dbm1.is_satisfying(1, 0, bound_t::non_strict(-2)));
+    BOOST_CHECK(dbm1.is_satisfying(1, 0, bound_t::inf()));
 }
 
 BOOST_AUTO_TEST_CASE(intersection_test_3) {
@@ -827,19 +827,19 @@ BOOST_AUTO_TEST_CASE(intersection_test_3) {
     dbm1.restrict(1, 0, bound_t::non_strict(10));
     dbm2.restrict(0, 1, bound_t::strict(-10));
 
-    BOOST_CHECK(not dbm1.intersects(dbm2));
+    BOOST_CHECK(not dbm1.is_intersecting(dbm2));
 
     dbm1.intersection(dbm2);
 
     BOOST_CHECK(dbm1.is_empty());
-    BOOST_CHECK(not dbm1.intersects(dbm2));
-    BOOST_CHECK(not dbm2.intersects(dbm1));
+    BOOST_CHECK(not dbm1.is_intersecting(dbm2));
+    BOOST_CHECK(not dbm2.is_intersecting(dbm1));
 
     dbm2.intersection(dbm1);
 
     BOOST_CHECK(dbm2.is_empty());
-    BOOST_CHECK(not dbm1.intersects(dbm2));
-    BOOST_CHECK(not dbm2.intersects(dbm1));
+    BOOST_CHECK(not dbm1.is_intersecting(dbm2));
+    BOOST_CHECK(not dbm2.is_intersecting(dbm1));
 }
 
 BOOST_AUTO_TEST_CASE(is_unbounded_test_1) {
@@ -942,24 +942,24 @@ BOOST_AUTO_TEST_CASE(intersects_test_1) {
     DBM dbm1(3);
     DBM dbm2(3);
 
-    BOOST_CHECK(dbm1.intersects(dbm2));
-    BOOST_CHECK(dbm2.intersects(dbm1));
+    BOOST_CHECK(dbm1.is_intersecting(dbm2));
+    BOOST_CHECK(dbm2.is_intersecting(dbm1));
     dbm1.future();
 
-    BOOST_CHECK(dbm1.intersects(dbm2));
-    BOOST_CHECK(dbm2.intersects(dbm1));
+    BOOST_CHECK(dbm1.is_intersecting(dbm2));
+    BOOST_CHECK(dbm2.is_intersecting(dbm1));
 
     dbm1.free(1);
     dbm1.free(2);
 
-    BOOST_CHECK(dbm1.intersects(dbm2));
-    BOOST_CHECK(dbm2.intersects(dbm1));
+    BOOST_CHECK(dbm1.is_intersecting(dbm2));
+    BOOST_CHECK(dbm2.is_intersecting(dbm1));
 
     dbm1.restrict(0, 1, bound_t::strict(-2));
     dbm1.restrict(0, 2, bound_t::strict(-3));
 
-    BOOST_CHECK(not dbm1.intersects(dbm2));
-    BOOST_CHECK(not dbm2.intersects(dbm1));
+    BOOST_CHECK(not dbm1.is_intersecting(dbm2));
+    BOOST_CHECK(not dbm2.is_intersecting(dbm1));
 }
 
 BOOST_AUTO_TEST_CASE(intersects_test_2) {
@@ -969,8 +969,8 @@ BOOST_AUTO_TEST_CASE(intersects_test_2) {
     dbm1.future();
     dbm2.restrict(0, 1, bound_t::strict(-1));
 
-    BOOST_CHECK(not dbm1.intersects(dbm2));
-    BOOST_CHECK(not dbm2.intersects(dbm1));
+    BOOST_CHECK(not dbm1.is_intersecting(dbm2));
+    BOOST_CHECK(not dbm2.is_intersecting(dbm1));
 }
 
 BOOST_AUTO_TEST_CASE(intersects_test_3) {
@@ -980,8 +980,8 @@ BOOST_AUTO_TEST_CASE(intersects_test_3) {
     dbm1.restrict(1, 0, bound_t::strict(1));
     dbm2.restrict(0, 1, bound_t::strict(-1));
     
-    BOOST_CHECK(not dbm1.intersects(dbm2));
-    BOOST_CHECK(not dbm2.intersects(dbm1));
+    BOOST_CHECK(not dbm1.is_intersecting(dbm2));
+    BOOST_CHECK(not dbm2.is_intersecting(dbm1));
 }
 
 BOOST_AUTO_TEST_CASE(zero_test_1) {

--- a/test/Federation_test.cpp
+++ b/test/Federation_test.cpp
@@ -88,17 +88,17 @@ BOOST_AUTO_TEST_CASE(subtract_test_1) {
 
     dbm.restrict(1, 0, bound_t::strict(10));
 
-    BOOST_CHECK(fed.satisfies(1, 0, bound_t::non_strict(11)));
-    BOOST_CHECK(fed.satisfies(1, 0, bound_t::non_strict(10)));
-    BOOST_CHECK(fed.satisfies(1, 0, bound_t::strict(10)));
-    BOOST_CHECK(fed.satisfies(1, 0, bound_t::non_strict(5)));
+    BOOST_CHECK(fed.is_satisfying(1, 0, bound_t::non_strict(11)));
+    BOOST_CHECK(fed.is_satisfying(1, 0, bound_t::non_strict(10)));
+    BOOST_CHECK(fed.is_satisfying(1, 0, bound_t::strict(10)));
+    BOOST_CHECK(fed.is_satisfying(1, 0, bound_t::non_strict(5)));
 
     fed.subtract(dbm);
 
-    BOOST_CHECK(fed.satisfies(1, 0, bound_t::non_strict(11)));
-    BOOST_CHECK(fed.satisfies(1, 0, bound_t::non_strict(10)));
-    BOOST_CHECK(not fed.satisfies(1, 0, bound_t::strict(10)));
-    BOOST_CHECK(not fed.satisfies(1, 0, bound_t::non_strict(5)));
+    BOOST_CHECK(fed.is_satisfying(1, 0, bound_t::non_strict(11)));
+    BOOST_CHECK(fed.is_satisfying(1, 0, bound_t::non_strict(10)));
+    BOOST_CHECK(not fed.is_satisfying(1, 0, bound_t::strict(10)));
+    BOOST_CHECK(not fed.is_satisfying(1, 0, bound_t::non_strict(5)));
 }
 
 BOOST_AUTO_TEST_CASE(remove_test_1) {
@@ -127,10 +127,10 @@ BOOST_AUTO_TEST_CASE(satisfies_test_1) {
     fed.future();
     fed.restrict(1, 0, bound_t::non_strict(5));
 
-    BOOST_CHECK(fed.satisfies(1, 0, bound_t::non_strict(5)));
-    BOOST_CHECK(fed.satisfies(1, 0, bound_t::strict(5)));
-    BOOST_CHECK(fed.satisfies(0, 1, bound_t::non_strict(-3)));
-    BOOST_CHECK(not fed.satisfies(0, 1, bound_t::non_strict(-6)));
+    BOOST_CHECK(fed.is_satisfying(1, 0, bound_t::non_strict(5)));
+    BOOST_CHECK(fed.is_satisfying(1, 0, bound_t::strict(5)));
+    BOOST_CHECK(fed.is_satisfying(0, 1, bound_t::non_strict(-3)));
+    BOOST_CHECK(not fed.is_satisfying(0, 1, bound_t::non_strict(-6)));
 
 }
 
@@ -464,12 +464,12 @@ BOOST_AUTO_TEST_CASE(intersects_test_1) {
     auto dbm = DBM::zero(3);
 
     BOOST_CHECK(fed.intersects(dbm));
-    BOOST_CHECK(dbm.intersects(fed));
+    BOOST_CHECK(dbm.is_intersecting(fed));
 
     fed.future();
 
     BOOST_CHECK(fed.intersects(dbm));
-    BOOST_CHECK(dbm.intersects(fed));
+    BOOST_CHECK(dbm.is_intersecting(fed));
 
     auto dbm2 = DBM::unconstrained(3);
     dbm2.restrict(0, 1, bound_t::strict(-2));
@@ -478,22 +478,22 @@ BOOST_AUTO_TEST_CASE(intersects_test_1) {
 
     BOOST_CHECK(fed.size() == 2);
     BOOST_CHECK(fed.intersects(dbm));
-    BOOST_CHECK(dbm.intersects(fed));
+    BOOST_CHECK(dbm.is_intersecting(fed));
 
     dbm.future();
 
     BOOST_CHECK(fed.intersects(dbm));
-    BOOST_CHECK(dbm.intersects(fed));
+    BOOST_CHECK(dbm.is_intersecting(fed));
 
     dbm.shift(1, 1);
 
     BOOST_CHECK(fed.intersects(dbm));
-    BOOST_CHECK(dbm.intersects(fed));
+    BOOST_CHECK(dbm.is_intersecting(fed));
 
     dbm.restrict(1, 0, bound_t::strict(2));
 
     BOOST_CHECK(not fed.intersects(dbm));
-    BOOST_CHECK(not dbm.intersects(fed));
+    BOOST_CHECK(not dbm.is_intersecting(fed));
 }
 
 BOOST_AUTO_TEST_CASE(intersects_test_2) {
@@ -621,17 +621,17 @@ BOOST_AUTO_TEST_CASE(intersection_test_3) {
 
     dbm2.restrict(2, 0, bound_t::strict(1));
 
-    BOOST_CHECK(fed.satisfies(0, 2, bound_t::non_strict(-1)));
+    BOOST_CHECK(fed.is_satisfying(0, 2, bound_t::non_strict(-1)));
 
     fed.intersection(dbm2);
 
     BOOST_CHECK(not fed.is_equal(dbm2));
     BOOST_CHECK(not fed.is_empty());
     BOOST_CHECK(fed.size() == 2);
-    BOOST_CHECK(fed.satisfies(1, 0, bound_t::strict(2)));
-    BOOST_CHECK(fed.satisfies(0, 1, bound_t::strict(-2)));
-    BOOST_CHECK(not fed.satisfies(0, 2, bound_t::non_strict(-1)));
-    BOOST_CHECK(fed.satisfies(2, 0, bound_t::non_strict(1)));
+    BOOST_CHECK(fed.is_satisfying(1, 0, bound_t::strict(2)));
+    BOOST_CHECK(fed.is_satisfying(0, 1, bound_t::strict(-2)));
+    BOOST_CHECK(not fed.is_satisfying(0, 2, bound_t::non_strict(-1)));
+    BOOST_CHECK(fed.is_satisfying(2, 0, bound_t::non_strict(1)));
 }
 
 BOOST_AUTO_TEST_CASE(intersection_test_4) {
@@ -680,15 +680,15 @@ BOOST_AUTO_TEST_CASE(intersection_test_6) {
 
     BOOST_CHECK(fed1.intersects(fed2));
     BOOST_CHECK(not fed1.is_empty());
-    BOOST_CHECK(fed1.satisfies(1, 0, bound_t::non_strict(2)));
-    BOOST_CHECK(fed1.satisfies(1, 0, bound_t::strict(3)));
+    BOOST_CHECK(fed1.is_satisfying(1, 0, bound_t::non_strict(2)));
+    BOOST_CHECK(fed1.is_satisfying(1, 0, bound_t::strict(3)));
 
     fed1.intersection(fed2);
 
     BOOST_CHECK(not fed1.is_empty());
     BOOST_CHECK(fed1.size() == 1);
-    BOOST_CHECK(not fed1.satisfies(1, 0, bound_t::non_strict(2)));
-    BOOST_CHECK(fed1.satisfies(1, 0, bound_t::strict(3)));
+    BOOST_CHECK(not fed1.is_satisfying(1, 0, bound_t::non_strict(2)));
+    BOOST_CHECK(fed1.is_satisfying(1, 0, bound_t::strict(3)));
 }
 
 BOOST_AUTO_TEST_CASE(remove_clock_test_1) {

--- a/test/bound_test.cpp
+++ b/test/bound_test.cpp
@@ -141,6 +141,22 @@ BOOST_AUTO_TEST_CASE(add_test_4) {
     BOOST_CHECK(a + b == bound_t::zero());
 }
 
+BOOST_AUTO_TEST_CASE(add_test_5) {
+    auto a = bound_t::inf();
+    auto b = a + 5;
+
+    BOOST_CHECK(a + 5 == b);
+    BOOST_CHECK(b == bound_t::inf());
+    BOOST_CHECK(b.get_bound() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(add_test_6) {
+    auto a = bound_t::strict(5);
+    auto b = a + 5;
+
+    BOOST_CHECK(b == bound_t::strict(10));
+}
+
 BOOST_AUTO_TEST_CASE(subtract_test_1) {
     bound_t a(5, STRICT);
 
@@ -148,4 +164,34 @@ BOOST_AUTO_TEST_CASE(subtract_test_1) {
     BOOST_CHECK(a - 10 == bound_t::strict(-5));
     BOOST_CHECK(a - 5 == bound_t::strict(0));
     BOOST_CHECK(a - 0 == bound_t::strict(5));
+}
+
+BOOST_AUTO_TEST_CASE(subtract_test_2) {
+    auto a = bound_t::strict(5);
+    auto b = a - 5;
+
+    BOOST_CHECK(b == bound_t::strict(0));
+}
+
+BOOST_AUTO_TEST_CASE(subtract_test_3) {
+    auto a = bound_t::inf();
+    auto b = a - 5;
+
+    BOOST_CHECK(b == bound_t::inf());
+    BOOST_CHECK(b.get_bound() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(multiply_test_1) {
+    auto a = bound_t::strict(5);
+    auto b = a * 5;
+
+    BOOST_CHECK(b == bound_t::strict(25));
+}
+
+BOOST_AUTO_TEST_CASE(multiply_test_2) {
+    auto a = bound_t::inf();
+    auto b = a * 5;
+
+    BOOST_CHECK(b == bound_t::inf());
+    BOOST_CHECK(b.get_bound() == 0);
 }


### PR DESCRIPTION
Check for infinity when using arithmetic operators between `bound_t` and `val_t`
Make `interval_delay(val_t)` the general implementation of `delay(val_t)` and `future(val_t)`