### PR TITLE
Subtract bounds from DBMs

### DIFF
--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -61,6 +61,17 @@ namespace pardibaal {
         this->_bounds_table.set(constraint._i, constraint._j, constraint._bound);
     }
 
+    void DBM::subtract(dim_t i, dim_t j, bound_t bound) {
+        if (this->at(i, j) > bound) // if i,j,bound is larger than current, then result is empty. Always false if bound is inf
+            this->restrict(j, i, bound_t(-bound.get_bound(), bound.is_non_strict()));
+        else
+            this->set(0, 0, bound_t::non_strict(-1));
+    }
+
+    void DBM::subtract(clock_constraint_t constraint) {
+        this->subtract(constraint._i, constraint._j, constraint._bound);
+    }
+
     dim_t DBM::dimension() const {return this->_bounds_table.number_of_clocks();}
 
     bool DBM::is_empty() const {
@@ -265,7 +276,6 @@ namespace pardibaal {
                 }
             }
         }
-
     }
 
     void DBM::restrict(const clock_constraint_t& constraint) {

--- a/src/pardibaal/DBM.h
+++ b/src/pardibaal/DBM.h
@@ -71,6 +71,9 @@ namespace pardibaal {
         void set(dim_t i, dim_t j, bound_t bound);
         void set(const clock_constraint_t& constraint);
 
+        void subtract(dim_t i, dim_t j, bound_t bound);
+        void subtract(clock_constraint_t constraint);
+
         [[nodiscard]] dim_t dimension() const;
 
         [[nodiscard]] bool is_empty() const;

--- a/test/DBM_test.cpp
+++ b/test/DBM_test.cpp
@@ -177,6 +177,27 @@ BOOST_AUTO_TEST_CASE(restrict_test_2) {
     BOOST_CHECK(D.is_empty());
 }
 
+BOOST_AUTO_TEST_CASE(subtract_test_1) {
+    DBM D(3);
+    bound_t g = bound_t::inf();
+
+    D.future();
+    D.subtract(1, 0, g);
+
+    BOOST_CHECK(D.is_empty());
+}
+
+BOOST_AUTO_TEST_CASE(subtract_test_2) {
+    DBM D = DBM::unconstrained(3);
+    bound_t g = bound_t::strict(1);
+
+    D.subtract(1, 2, g);
+
+    BOOST_CHECK(not D.is_satisfying(1, 2, g));
+    BOOST_CHECK(D.is_satisfying(1, 2, bound_t::non_strict(1)));
+    BOOST_CHECK(D.is_satisfying(2, 1, bound_t::inf()));
+}
+
 BOOST_AUTO_TEST_CASE(trace_test_1) {
     DBM D(4);
     dim_t x = 1, y = 2, z = 3;

--- a/test/Federation_test.cpp
+++ b/test/Federation_test.cpp
@@ -726,3 +726,51 @@ BOOST_AUTO_TEST_CASE(unconstrained_test_1) {
 
     BOOST_CHECK(fed.is_equal(Federation::unconstrained(dim)));
 }
+
+BOOST_AUTO_TEST_CASE(something) {
+    auto red1 = DBM::unconstrained(3);
+    auto blue1 = DBM::unconstrained(3);
+    auto red2 = DBM::unconstrained(3);
+    auto blue2 = DBM::unconstrained(3);
+    //x = 1, y = 2
+    red1.restrict({clock_constraint_t::upper_non_strict(2, 3), 
+                   clock_constraint_t::upper_non_strict(1, 2),
+                   clock_constraint_t::lower_non_strict(2, 1),
+                   clock_constraint_t::lower_non_strict(1, 1)});
+
+    red1.restrict(clock_constraint_t(2, 0, bound_t(3, false)));
+    red1.restrict(2, 0, bound_t::non_strict(3));
+
+    blue1.restrict({clock_constraint_t::upper_non_strict(2, 2),
+                    clock_constraint_t::upper_non_strict(1, 3),
+                    clock_constraint_t(2, 1, bound_t::zero()),
+                    clock_constraint_t(1, 2, bound_t::non_strict(2))});
+    
+    red2.restrict({clock_constraint_t::upper_non_strict(2, 3), 
+                   clock_constraint_t::upper_non_strict(1, 2),
+                   clock_constraint_t::lower_non_strict(1, 1),
+                   clock_constraint_t(2, 1, bound_t::non_strict(1))});
+
+    blue2.restrict({clock_constraint_t::upper_non_strict(2, 2),
+                    clock_constraint_t::upper_non_strict(1, 3),
+                    clock_constraint_t(2, 1, bound_t::non_strict(-1)),
+                    clock_constraint_t(1, 2, bound_t::non_strict(2))});
+
+    auto fed1 = Federation(red1);
+    fed1.add(blue1);
+
+    auto fed2 = Federation(red2);
+    fed2.add(blue2);
+
+    relation_t rel12 = fed1.exact_relation(fed2);
+    relation_t rel21 = fed2.exact_relation(fed1);
+
+    BOOST_CHECK(rel12.is_superset());
+    BOOST_CHECK(rel21.is_subset());
+
+    rel12 = fed1.approx_relation(fed2);
+    rel21 = fed2.approx_relation(fed1);
+
+    BOOST_CHECK(rel12.is_different());
+    BOOST_CHECK(rel21.is_different());
+}


### PR DESCRIPTION
adds functionality of subtracting bounds from DBMs. Makes it convenient to get a zone that does *not* satisfy a given bound. 