### PR TITLE
Compressed bounds

### DIFF
--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -108,7 +108,9 @@ namespace pardibaal {
     }
 
     relation_t DBM::relation(const DBM &dbm) const {
-        if (this->dimension() != dbm.dimension())
+        const auto dim = this->dimension();
+
+        if (dim != dbm.dimension())
             return relation_t::different();
         else if (this->is_empty())
             return dbm.is_empty() ? relation_t::equal() : relation_t::subset();
@@ -117,8 +119,8 @@ namespace pardibaal {
 
         bool eq = true, sub = true, super = true;
 
-        for (dim_t i = 0; i < dimension(); ++i)
-            for (dim_t j = 0; j < dimension(); ++j) {
+        for (dim_t i = 0; i < dim; ++i)
+            for (dim_t j = 0; j < dim; ++j) {
                 sub = sub && this->at(i, j) <= dbm.at(i, j);
                 super = super && this->at(i, j) >= dbm.at(i, j);
                 if (!sub && !super) return relation_t::different();
@@ -180,14 +182,15 @@ namespace pardibaal {
     template bool DBM::is_different<false>(const Federation& fed) const;
 
     bool DBM::is_intersecting(const DBM &dbm) const {
+        const auto dim = this->dimension();
 #ifndef NEXCEPTIONS
-        if (dbm.dimension() != dimension())
+        if (dbm.dimension() != this->dimension())
             throw(base_error("ERROR: Cannot measure intersection of two dbms with different dimensions. ",
-                             "Got dimensions ", dbm.dimension(), " and ", dimension()));
+                             "Got dimensions ", dbm.dimension(), " and ", dim));
 #endif
         if (this->is_empty() || dbm.is_empty()) return false;
-        for (dim_t i = 0; i < dimension(); ++i) {
-            for (dim_t j = 0; j < dimension(); ++j) {
+        for (dim_t i = 0; i < dim; ++i) {
+            for (dim_t j = 0; j < dim; ++j) {
                 bound_t b1 = this->at(i, j);
                 bound_t b2 = dbm.at(j, i);
 
@@ -212,7 +215,8 @@ namespace pardibaal {
     bool DBM::is_unbounded() const {
         if (is_empty()) return false;
 
-        for (dim_t i = 1; i < dimension(); ++i)
+        const auto dim = this->dimension();
+        for (dim_t i = 1; i < dim; ++i)
             if (not this->at(i, 0).is_inf())
                 return false;
 
@@ -222,11 +226,11 @@ namespace pardibaal {
     void DBM::close() {
         if (_is_closed) return;
 
-        const dim_t size = this->dimension();
+        const dim_t dim = this->dimension();
 
-        for(dim_t k = 0; k < size; ++k)
-            for(dim_t i = 0; i < size; ++i)
-                for(dim_t j = 0; j < size; ++j)
+        for(dim_t k = 0; k < dim; ++k)
+            for(dim_t i = 0; i < dim; ++i)
+                for(dim_t j = 0; j < dim; ++j)
                     _bounds_table.set(i, j, bound_t::min(_bounds_table.at(i, j),
                                                          _bounds_table.at(i, k) + _bounds_table.at(k, j)));
 
@@ -234,15 +238,17 @@ namespace pardibaal {
     }
 
     void DBM::close_single_bound(dim_t i, dim_t j) {
-        const dim_t size = this->dimension();
+        const dim_t dim = this->dimension();
 
-        for(dim_t k = 0; k < size; ++k)
+        for(dim_t k = 0; k < dim; ++k)
             _bounds_table.set(i, j, bound_t::min(_bounds_table.at(i, j), 
                               _bounds_table.at(i, k) + _bounds_table.at(k, j)));
     }
 
     void DBM::future() {
-        for (dim_t i = 1; i < this->dimension(); ++i)
+        const dim_t dim = this->dimension();
+
+        for (dim_t i = 1; i < dim; ++i)
             _bounds_table.set(i, 0, bound_t::inf());
     }
 
@@ -251,9 +257,10 @@ namespace pardibaal {
     }
 
     void DBM::past() {
-        for (dim_t i = 1; i < this->dimension(); ++i) {
+        const auto dim = this->dimension();
+        for (dim_t i = 1; i < dim; ++i) {
             this->_bounds_table.set(0, i, bound_t::le_zero());
-            for (dim_t j = 1; j < this->dimension(); ++j) {
+            for (dim_t j = 1; j < dim; ++j) {
                 if (this->_bounds_table.at(j, i) < this->_bounds_table.at(0, i)) {
                     this->_bounds_table.set(0, i, this->_bounds_table.at(j, i));
                 }
@@ -272,8 +279,10 @@ namespace pardibaal {
         if (lower > upper)
             throw(base_error("ERROR: lower value of delay interval must be smaller than the upper valuer"));
 #endif
+        const auto dim = this->dimension();
+
         if (lower > 0 || upper > 0) {
-            for (dim_t i = 1; i < this->dimension(); ++i) {
+            for (dim_t i = 1; i < dim; ++i) {
                 this->set(0, i, this->at(0, i) - lower); // Raise lower bounds
                 this->set(i, 0, this->at(i, 0) + upper); // Raise upper bounds
             }
@@ -285,8 +294,10 @@ namespace pardibaal {
             _empty_status = EMPTY;
         else if (g < _bounds_table.at(x, y)) {
             _bounds_table.set(x, y, g);
-            for (dim_t i = 0; i < this->dimension(); ++i) {
-                for (dim_t j = 0; j < this->dimension(); ++j) {
+
+            const auto dim = this->dimension();
+            for (dim_t i = 0; i < dim; ++i) {
+                for (dim_t j = 0; j < dim; ++j) {
                     if (_bounds_table.at(i, x) + _bounds_table.at(x, j) < _bounds_table.at(i, j))
                         _bounds_table.set(i, j, _bounds_table.at(i, x) + _bounds_table.at(x, j));
 
@@ -307,7 +318,9 @@ namespace pardibaal {
     }
 
     void DBM::free(dim_t x) {
-        for (dim_t i = 0; i < dimension(); ++i) {
+       const auto dim = this->dimension();
+
+        for (dim_t i = 0; i < dim; ++i) {
             if (i != x) {
                 _bounds_table.set(x, i, bound_t::inf());
                 _bounds_table.set(i, x, _bounds_table.at(i, 0));
@@ -317,7 +330,9 @@ namespace pardibaal {
 
     // x := m
     void DBM::assign(dim_t x, val_t m) {
-        for (dim_t i = 0; i < this->dimension(); ++i) {
+        const auto dim = this->dimension();
+
+        for (dim_t i = 0; i < dim; ++i) {
             _bounds_table.set(x, i, bound_t::non_strict(m) + _bounds_table.at(0, i));
             _bounds_table.set(i, x, bound_t::non_strict(-m) + _bounds_table.at(i, 0));
         }
@@ -325,7 +340,9 @@ namespace pardibaal {
 
     // x := y
     void DBM::copy(dim_t x, dim_t y) {
-        for (dim_t i = 0; i < this->dimension(); ++i) {
+        const auto dim = this->dimension();
+
+        for (dim_t i = 0; i < dim; ++i) {
             if (i != x) {
                 _bounds_table.set(x, i, _bounds_table.at(y, i));
                 _bounds_table.set(i, x, _bounds_table.at(i, y));
@@ -336,7 +353,9 @@ namespace pardibaal {
     }
 
     void DBM::shift(dim_t x, val_t n) {
-        for (dim_t i = 0; i < this->dimension(); ++i) {
+        const auto dim = this->dimension();
+
+        for (dim_t i = 0; i < dim; ++i) {
             if (i != x) {
                 this->_bounds_table.set(x, i, this->_bounds_table.at(x, i) + bound_t::non_strict(n));
                 this->_bounds_table.set(i, x, this->_bounds_table.at(i, x) + bound_t::non_strict(-n));
@@ -348,14 +367,16 @@ namespace pardibaal {
 
     // Simple extrapolation from a ceiling for all clocks.
     void DBM::extrapolate(const std::vector<val_t> &ceiling) {
+        const auto dim = this->dimension();
+
 #ifndef NEXCEPTIONS
-        if (this->dimension() != ceiling.size())
+        if (dim != ceiling.size())
             throw base_error("ERROR: Got max constants vector of size ", ceiling.size(), " but the DBM has ",
-                             this->dimension(), " clocks");
+                             dim, " clocks");
 #endif
 
-        for (dim_t i = 0; i < this->dimension(); ++i) {
-            for (dim_t j = 0; j < this->dimension(); ++j) {
+        for (dim_t i = 0; i < dim; ++i) {
+            for (dim_t j = 0; j < dim; ++j) {
                 if (!this->_bounds_table.at(i, j).is_inf() && this->_bounds_table.at(i, j) > bound_t::non_strict(ceiling[i])){
                     this->_bounds_table.set(i, j, bound_t::inf());
                 }
@@ -370,17 +391,19 @@ namespace pardibaal {
     }
 
     void DBM::extrapolate_diagonal(const std::vector<val_t> &ceiling) {
+        const auto dim = this->dimension();
+
 #ifndef NEXCEPTIONS
-        if (this->dimension() != ceiling.size())
+        if (dim != ceiling.size())
             throw base_error("ERROR: Got max constants vector of size ", ceiling.size(), " but the DBM has ",
-                             this->dimension(), " clocks");
+                             dim, " clocks");
 #endif
         DBM D(*this);
 
         std::vector<std::pair<dim_t, dim_t>> modified_bounds;
 
-        for (dim_t i = 0; i < D.dimension(); ++i) {
-            for (dim_t j = 0; j < D.dimension(); ++j) {
+        for (dim_t i = 0; i < dim; ++i) {
+            for (dim_t j = 0; j < dim; ++j) {
                 if (i == j) continue;
                 if ((D.at(i, j).get_bound() > ceiling[i]) ||
                         (-D.at(0, i).get_bound() > ceiling[i]) ||
@@ -415,15 +438,17 @@ namespace pardibaal {
     }
 
     void DBM::extrapolate_lu(const std::vector<val_t> &lower, const std::vector<val_t> &upper) {
+        const auto dim = this->dimension();
+
 #ifndef NEXCEPTIONS
-        if (this->dimension() != lower.size() || this->dimension() != upper.size())
+        if (dim != lower.size() || dim != upper.size())
             throw base_error("ERROR: Got LU constants vector of size ", lower.size(), " and ", upper.size(),
-                             " but the DBM has ", this->dimension(), " clocks");
+                             " but the DBM has ", dim, " clocks");
 #endif
         DBM D(*this);
 
-        for (dim_t i = 0; i < D.dimension(); ++i) {
-            for (dim_t j = 0; j < D.dimension(); ++j) {
+        for (dim_t i = 0; i < dim; ++i) {
+            for (dim_t j = 0; j < dim; ++j) {
                 if (i == j) continue;
                 else if (D.at(i, j).get_bound() > lower[i])
                     this->set(i, j, bound_t::inf());
@@ -446,15 +471,17 @@ namespace pardibaal {
     }
 
     void DBM::extrapolate_lu_diagonal(const std::vector<val_t> &lower, const std::vector<val_t> &upper) {
+        const auto dim = this->dimension();
+
 #ifndef NEXCEPTIONS
-        if (this->dimension() != lower.size() || this->dimension() != upper.size())
+        if (dim != lower.size() || dim != upper.size())
             throw base_error("ERROR: Got LU constants vector of size ", lower.size(), " and ", upper.size(),
-                             " but the DBM has ", this->dimension(), " clocks");
+                             " but the DBM has ", dim, " clocks");
 #endif
         DBM D(*this);
 
-        for (dim_t i = 0; i < D.dimension(); ++i) {
-            for (dim_t j = 0; j < D.dimension(); ++j) {
+        for (dim_t i = 0; i < dim; ++i) {
+            for (dim_t j = 0; j < dim; ++j) {
                 if (i == j) continue;
                 else if ((D.at(i, j).get_bound() > lower[i]) ||
                          (-D.at(0, i).get_bound() > -lower[i]) ||
@@ -479,18 +506,20 @@ namespace pardibaal {
     }
 
     void DBM::intersection(const DBM &dbm) {
+        const auto dim = this->dimension();
+
 #ifndef NEXCEPTIONS
-        if (dbm.dimension() != dimension())
+        if (dbm.dimension() != dim)
             throw(base_error("ERROR: Cannot take intersection of two dbms with different dimensions. ",
-                             "Got dimensions ", dbm.dimension(), " and ", dimension()));
+                             "Got dimensions ", dbm.dimension(), " and ", dim));
 #endif
         if (dbm.is_empty() || this->is_empty()) {
             this->_empty_status = EMPTY;
             return;
         }
 
-        for (dim_t i = 0; i < dimension(); ++i)
-            for (dim_t j = 0; j < dimension(); ++j)
+        for (dim_t i = 0; i < dim; ++i)
+            for (dim_t j = 0; j < dim; ++j)
                 this->_bounds_table.set(i, j, bound_t::min(this->at(i, j), dbm.at(i, j)));
 
         _empty_status = UNKNOWN;
@@ -499,17 +528,19 @@ namespace pardibaal {
     }
 
     void DBM::remove_clock(dim_t c) {
+        const auto dim = this->dimension();
+
 #ifndef NEXCEPTIONS
         if (c == 0)
             throw base_error("ERROR: Cannot remove the zero clock");
-        if (c >= this->dimension())
-            throw base_error("ERROR: Removing clock ", c, " but the DBM only has clocks from 0 to ", dimension() - 1);
+        if (c >= dim)
+            throw base_error("ERROR: Removing clock ", c, " but the DBM only has clocks from 0 to ", dim - 1);
 #endif
-        DBM D(dimension() - 1);
+        DBM D(dim - 1);
 
-        for (dim_t i = 0, i2 = 0; i < dimension(); ++i, ++i2) {
-            for (dim_t j = 0, j2 = 0; j < dimension(); ++j) {
-                if (i == c && i < dimension() -1) {++i;}
+        for (dim_t i = 0, i2 = 0; i < dim; ++i, ++i2) {
+            for (dim_t j = 0, j2 = 0; j < dim; ++j) {
+                if (i == c && i < dim -1) {++i;}
                 if (j == c || i == c) continue;
 
                 D._bounds_table.set(i2, j2++, this->at(i, j));
@@ -520,16 +551,18 @@ namespace pardibaal {
     }
 
     void DBM::swap_clocks(dim_t a, dim_t b) {
+        const auto dim = this->dimension();
+
 #ifndef NEXCEPTIONS
         if (a == 0 || b == 0)
             throw base_error("ERROR: Cannot swap the zero clock");
-        if (a >= this->dimension() || b >= this->dimension())
-            throw base_error("ERROR: Swapping clock ", a, " and ", b, " but the DBM only has clocks from 0 to ", dimension() - 1);
+        if (a >= dim || b >= dim)
+            throw base_error("ERROR: Swapping clock ", a, " and ", b, " but the DBM only has clocks from 0 to ", dim - 1);
 #endif
         if (a == b) return;
 
         bound_t tmp;
-        for (dim_t i = 0; i < dimension(); ++i) {
+        for (dim_t i = 0; i < dim; ++i) {
             if (!(i == a || i == b)) {
                 tmp = at(i, a);
                 _bounds_table.set(i, a, at(i, b));
@@ -547,18 +580,20 @@ namespace pardibaal {
     }
 
     void DBM::add_clock_at(dim_t c) {
+        const auto dim = this->dimension();
+
 #ifndef NEXCEPTIONS
         if (c == 0)
             throw base_error("ERROR: Cannot add a new clock at index zero");
-        if (c > this->dimension())
-            throw base_error("ERROR: Adding clock at index", c, " but the DBM only has clocks from 0 to ", dimension() - 1);
+        if (c > dim)
+            throw base_error("ERROR: Adding clock at index", c, " but the DBM only has clocks from 0 to ", dim - 1);
 #endif
 
-        DBM D(dimension() + 1);
+        DBM D(dim + 1);
 
-        for (dim_t i = 0, i2 = 0; i < D.dimension(); ++i, ++i2) {
-            for (dim_t j = 0, j2 = 0; j < D.dimension(); ++j) {
-                if (i == c && i < D.dimension() - 1) {++i;}
+        for (dim_t i = 0, i2 = 0; i < dim + 1; ++i, ++i2) {
+            for (dim_t j = 0, j2 = 0; j < dim + 1; ++j) {
+                if (i == c && i < dim) {++i;}
                 if (j == c || i == c) continue;
                 D._bounds_table.set(i, j, this->at(i2, j2++));
             }
@@ -572,10 +607,12 @@ namespace pardibaal {
         /* assume number of '1' bits in src_bits and dst_bits match, and
          * that the length of src_bits is the same as _number_of_clocks
          */
+        const auto dim = this->dimension();
+
 #ifndef NEXCEPTIONS
-        if (src_bits.size() != this->dimension())
+        if (src_bits.size() != dim)
             throw base_error("ERROR: src_bits has size: ", src_bits.size(), " but the dimension of the DBM is: ",
-                             this->dimension(), " but they must be equal");
+                             dim, " but they must be equal");
 
         int src = std::count_if(dst_bits.begin(), dst_bits.end(), [](bool b){return b;});
         int dst = std::count_if(src_bits.begin(), src_bits.end(), [](bool b){return b;});
@@ -588,7 +625,7 @@ namespace pardibaal {
         std::vector<dim_t> src_indir(src_bits.size(), 0);
         dim_t dst_cnt = 0;
 
-        for (dim_t i = 0; i < src_bits.size(); ++i) {
+        for (dim_t i = 0; i < dim; ++i) {
             if (src_bits[i]) {
                 while (not dst_bits[dst_cnt]) ++dst_cnt; // increment to first used position
                 src_indir[i] = dst_cnt++;
@@ -598,8 +635,8 @@ namespace pardibaal {
         }
 
         // dest(src_indir[i], src_indir[j] = src(i, j);
-        for (dim_t i = 0; i < src_indir.size(); ++i) {
-            for (dim_t j = 0; j < src_indir.size(); ++j) {
+        for (dim_t i = 0; i < dim; ++i) {
+            for (dim_t j = 0; j < dim; ++j) {
                 if (src_indir[i] != -1 && src_indir[j] != -1)
                     dest_dbm._bounds_table.set(src_indir[i], src_indir[j], this->_bounds_table.at(i, j));
             }
@@ -616,15 +653,17 @@ namespace pardibaal {
     }
 
     void DBM::reorder(const std::vector<dim_t>& order, dim_t new_size) {
+        const auto dim = this->dimension();
+
 #ifndef NEXCEPTIONS
-        if (order.size() != this->dimension())
+        if (order.size() != dim)
             throw base_error("ERROR: Order vector has size: ", order.size(), " but the dimension of the DBM is: ",
-                             this->dimension(), " They must be equal");
+                             dim, " They must be equal");
 
         int clocks_removed = std::count_if(order.begin(), order.end(), [](dim_t i){return i == ~0;});
-        if (this->dimension() - clocks_removed != new_size)
+        if (dim - clocks_removed != new_size)
             throw base_error("ERROR: new_size does not match the number of clocks removed. new_size is: ", new_size,
-                             " current size: ", this->dimension(), " Clocks removed: ", clocks_removed);
+                             " current size: ", dim, " Clocks removed: ", clocks_removed);
         for (const dim_t& i : order)
             if (i >= new_size && i != (dim_t) -1)
                 throw base_error("ERROR: order has value ", order[i], " on index ", i,
@@ -633,8 +672,8 @@ namespace pardibaal {
 
         DBM D(new_size);
 
-        for (dim_t i = 0; i < this->dimension(); ++i) {
-            for (dim_t j = 0; j < this->dimension(); ++j) {
+        for (dim_t i = 0; i < dim; ++i) {
+            for (dim_t j = 0; j < dim; ++j) {
                 if (order[i] != ~0 && order[j] != ~0)
                     D._bounds_table.set(order[i], order[j], this->_bounds_table.at(i, j));
             }

--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -488,8 +488,8 @@ namespace pardibaal {
             for (dim_t j = 0; j < dim; ++j) {
                 if (i == j) continue;
                 else if ((D.at(i, j).get_bound() > lower[i]) ||
-                         (-D.at(0, i).get_bound() > -lower[i]) ||
-                         (-D.at(0, j).get_bound() > -upper[j] && i != 0))
+                         (-D.at(0, i).get_bound() > lower[i]) ||
+                         (-D.at(0, j).get_bound() > upper[j] && i != 0))
                     this->set(i, j, bound_t::inf());
                 else if (-D.at(0, j).get_bound() > upper[j] && i == 0)
                     this->set(i, j, bound_t::strict(-upper[j]));

--- a/src/pardibaal/DBM.cpp
+++ b/src/pardibaal/DBM.cpp
@@ -76,9 +76,11 @@ namespace pardibaal {
         if (_empty_status != UNKNOWN)
             return _empty_status == EMPTY ? true : false;
 
+        const dim_t dim = this->dimension();
+
         // The DBM has to be closed for this to actually work
-        for (dim_t i = 0; i < this->dimension(); ++i) {
-            for (dim_t j = 0; j < this->dimension(); ++j) {
+        for (dim_t i = 0; i < dim; ++i) {
+            for (dim_t j = 0; j < dim; ++j) {
                 bound_t i_to_j_to_i = this->_bounds_table.at(i, j) + this->_bounds_table.at(j, i);
 
                 if (i_to_j_to_i < bound_t::le_zero()) {

--- a/src/pardibaal/Federation.cpp
+++ b/src/pardibaal/Federation.cpp
@@ -84,17 +84,18 @@ namespace pardibaal {
     }
 
     void Federation::subtract(const DBM& dbm) {
+    const auto dim = this->dimension();
 #ifndef NEXCEPTIONS
         if (!zones.empty()) {
-            if (dimension() != dbm.dimension())
+            if (dim != dbm.dimension())
                 throw base_error("ERROR: Subtracting dbm with dimension: ", dbm.dimension(),
-                                 " from a federation with dimension: ", dimension());
+                                 " from a federation with dimension: ", dim);
         }
 #endif
         auto fed = Federation();
         for (auto z : zones) {
-            for (dim_t i = 0; i < dimension(); ++i) {
-                for (dim_t j = 0; j < dimension(); ++j) {
+            for (dim_t i = 0; i < dim; ++i) {
+                for (dim_t j = 0; j < dim; ++j) {
                     // This check ensures that the zone added is non-empty iff it is on max canonical form.
                     if (z.at(i, j) > dbm.at(i, j)) {
                         z.restrict(j, i, bound_t(-dbm.at(i, j).get_bound(), dbm.at(i, j).is_non_strict()));

--- a/src/pardibaal/bound_t.cpp
+++ b/src/pardibaal/bound_t.cpp
@@ -61,7 +61,7 @@ namespace pardibaal {
         
         auto prod = this->get_bound() * rhs;
 
-        assert((this->get_bound() != 0 && prod / this->get_bound() != rhs)
+        assert((!(this->get_bound() != 0) || (prod / this->get_bound() == rhs))
                 && prod > BOUND_VAL_MIN && prod < BOUND_VAL_MAX
                 && rhs > BOUND_VAL_MIN && rhs < BOUND_VAL_MAX && ("Overflow or Underflow"));
 

--- a/src/pardibaal/bound_t.cpp
+++ b/src/pardibaal/bound_t.cpp
@@ -21,79 +21,59 @@
  */
 
 #include <ostream>
+#include <cassert>
 
 #include "bound_t.h"
 
 namespace pardibaal {
 
-    // val_t bound_t::get_bound()    const {return this->_n;}
-    // bool bound_t::is_strict()     const {return this->_strict;}
-    // bool bound_t::is_non_strict() const {return not this->_strict;}
-    // bool bound_t::is_inf()        const {return this->_inf;}
-
-    const bound_t &bound_t::max(const bound_t &a, const bound_t &b) {return a < b ? b : a;}
-    bound_t bound_t::max(bound_t &&a, bound_t &&b) {return max(a, b);}
-    bound_t bound_t::max(const bound_t &a, bound_t &&b) {return max(a, b);}
-    bound_t bound_t::max(bound_t &&a, const bound_t &b) {return max(a, b);}
-
-    const bound_t &bound_t::min(const bound_t &a, const bound_t &b) {return a <= b ? a : b;}
-    bound_t bound_t::min(bound_t &&a, bound_t &&b) {return bound_t::min(a, b);}
-    bound_t bound_t::min(const bound_t &a, bound_t &&b) {return bound_t::min(a, b);}
-    bound_t bound_t::min(bound_t &&a, const bound_t &b) {return bound_t::min(a, b);}
-
     bound_t bound_t::operator+(bound_t rhs) const {
+
         if (this->is_inf() || rhs.is_inf())
             return bound_t::inf();
+
+        assert(get_bound() < BOUND_VAL_MAX - rhs.get_bound() && "Overflow");
 
         return bound_t(this->get_bound() + rhs.get_bound(), this->is_strict() || rhs.is_strict());
     }
 
     bound_t bound_t::operator+(val_t rhs) const {
-        if (not this->is_inf())
-            return bound_t(this->get_bound() + rhs, this->is_strict());
-        return *this;
+        if (this->is_inf())
+            return *this;
+
+        assert(get_bound() < BOUND_VAL_MAX - rhs && "Overflow");
+
+        return bound_t(this->get_bound() + rhs, this->is_strict());
     }
 
     bound_t bound_t::operator-(val_t rhs) const {
-        if (not this->is_inf())
-            return bound_t(this->get_bound() - rhs, this->is_strict());
-        return *this;
+        if (this->is_inf())
+            return *this;
+
+        assert(get_bound() > BOUND_VAL_MIN + rhs && rhs > BOUND_VAL_MIN && rhs < BOUND_VAL_MAX && "Underflow");
+
+        return bound_t(this->get_bound() - rhs, this->is_strict());
     }
 
     bound_t bound_t::operator*(val_t rhs) const {
-        if (not this->is_inf())
-            return bound_t(this->get_bound() * rhs, this->is_strict());
-        return *this;
+        if (this->is_inf())
+            return *this;
+        
+        auto prod = this->get_bound() * rhs;
+
+        assert((this->get_bound() != 0 && prod / this->get_bound() != rhs)
+                && prod > BOUND_VAL_MIN && prod < BOUND_VAL_MAX
+                && rhs > BOUND_VAL_MIN && rhs < BOUND_VAL_MAX && ("Overflow or Underflow"));
+
+        return bound_t(this->get_bound() * rhs, this->is_strict());
     }
 
-    bool bound_t::operator<(bound_t rhs) const {
-        if (this->is_inf()) return false;
-        if (rhs.is_inf()) return true;
-
-        if (this->get_bound() == rhs.get_bound())
-            return !rhs.is_strict() && this->is_strict();
-
-        return this->get_bound() < rhs.get_bound();
-    }
-
-    bool bound_t::operator==(bound_t rhs) const {
-        if (this->is_inf() || rhs.is_inf())
-            return this->is_inf() && rhs.is_inf();
-
-        return (this->get_bound() == rhs.get_bound()) && (this->is_strict() == rhs.is_strict());
-    }
-
-    bool bound_t::operator!=(bound_t rhs) const {return not (*this == rhs);}
-    bool bound_t::operator>(bound_t rhs)  const {return rhs < *this;}
-    bool bound_t::operator>=(bound_t rhs) const {return not (*this < rhs);}
-    bool bound_t::operator<=(bound_t rhs) const {return not (rhs < *this);}
-
-    bool bound_t::operator==(val_t rhs) const {return *this == bound_t::non_strict(rhs);}
-    bool bound_t::operator!=(val_t rhs) const {return *this != bound_t::non_strict(rhs);}
-    bool bound_t::operator<(val_t rhs) const {return *this < bound_t::non_strict(rhs);}
-    bool bound_t::operator>(val_t rhs) const {return *this > bound_t::non_strict(rhs);}
-    bool bound_t::operator<=(val_t rhs) const {return *this <= bound_t::non_strict(rhs);}
-    bool bound_t::operator>=(val_t rhs) const {return *this >= bound_t::non_strict(rhs);}
+    bool bound_t::operator==(val_t rhs) const {return this->_data == bound_t::non_strict(rhs)._data;}
+    bool bound_t::operator!=(val_t rhs) const {return this->_data != bound_t::non_strict(rhs)._data;}
+    bool bound_t::operator<(val_t rhs) const {return this->_data < bound_t::non_strict(rhs)._data;}
+    bool bound_t::operator>(val_t rhs) const {return this->_data > bound_t::non_strict(rhs)._data;}
+    bool bound_t::operator<=(val_t rhs) const {return this->_data <= bound_t::non_strict(rhs)._data;}
+    bool bound_t::operator>=(val_t rhs) const {return this->_data >= bound_t::non_strict(rhs)._data;}
 
     bool lt(bound_t lhs, bound_t rhs) {return lhs < rhs;}
     bool le(bound_t lhs, bound_t rhs) {return lhs <= rhs;}

--- a/src/pardibaal/bound_t.h
+++ b/src/pardibaal/bound_t.h
@@ -79,7 +79,7 @@ namespace pardibaal {
         [[nodiscard]] inline val_t get_bound()    const {return this->_data >> 1;}
         [[nodiscard]] inline bool is_strict()     const {return not this->is_non_strict();}
         [[nodiscard]] inline bool is_non_strict() const {return this->_data << 31;}
-        [[nodiscard]] inline bool is_inf()        const {return this->_data & INF_BOUND;}
+        [[nodiscard]] inline bool is_inf()        const {return this->_data == INF_BOUND;}
 
         [[nodiscard]] static inline bound_t max(bound_t a, bound_t b) {return a < b ? b : a;}
         [[nodiscard]] static inline bound_t min(bound_t a, bound_t b) {return a < b ? a : b;}

--- a/src/pardibaal/bound_t.h
+++ b/src/pardibaal/bound_t.h
@@ -25,46 +25,64 @@
 
 #include <ostream>
 #include <cinttypes>
+#include <limits>
 
 
 namespace pardibaal {
     using dim_t = uint32_t;
     using val_t = int32_t;
 
+    /**
+     * Representing a bound in 32 bit:
+     * Least significant bit is strictness, 1 means non strict and 0 means strict.
+     * the 31 most significant bits are right shifted (preserving signed bit) and read as 32 bit signed int.
+     * Infinite bound is represented as the largesst 31 bit value.
+     * This means that the max limit for a bound value is a 32 bit int where the two most significant bits are 0
+     */
+    const int32_t INF_BOUND = std::numeric_limits<int32_t>::max();
+    const int32_t LE_ZERO_BOUND = 1;
+    const int32_t LT_ZERO_BOUND = 0;
+    const int32_t BOUND_VAL_MAX = std::numeric_limits<int32_t>::max() >> 1;
+    const int32_t BOUND_VAL_MIN = std::numeric_limits<int32_t>::min() >> 1;
+
     enum strict_e {STRICT, NON_STRICT};
 
     struct bound_t {
-    private:
-        val_t _n = 0;
-        bool _strict = false,
-             _inf = false;
 
-        constexpr bound_t(val_t n, bool strict, bool inf) : _n(n), _strict(strict), _inf(inf){};
+    private:
+        val_t _data = LE_ZERO_BOUND;
+
+        constexpr bound_t(val_t bound) : _data(bound) {}
+
     public:
         constexpr bound_t(){};
-        constexpr bound_t(val_t n, strict_e strictness) : _n(n) {_strict = strictness == STRICT ? true : false;}
-        constexpr bound_t(val_t n, bool strict) : _n(n), _strict(strict) {}
+        constexpr bound_t(val_t n, strict_e strictness) {
+            if (strictness == STRICT)
+                _data = n << 1;
+            else
+                _data = ~((~n) << 1);
+        }
 
-        [[nodiscard]] static constexpr bound_t strict(val_t n)     {return bound_t(n, true,  false);}
-        [[nodiscard]] static constexpr bound_t non_strict(val_t n) {return bound_t(n, false, false);}
-        [[nodiscard]] static constexpr bound_t inf()               {return bound_t(0, true,  true);}
-        [[nodiscard]] static constexpr bound_t le_zero()           {return bound_t(0, false, false);}
-        [[nodiscard]] static constexpr bound_t lt_zero()           {return bound_t(0, true,  false);}
+        constexpr bound_t(val_t n, bool strict) {
+            if (strict)
+                _data = n << 1;
+            else
+                _data = ~((~n) << 1);
+        }
 
-        [[nodiscard]] inline val_t get_bound()    const {return this->_n;}
-        [[nodiscard]] inline bool is_strict()     const {return this->_strict;}
-        [[nodiscard]] inline bool is_non_strict() const {return not this->_strict;}
-        [[nodiscard]] inline bool is_inf()        const {return this->_inf;}
+        [[nodiscard]] static constexpr bound_t strict(val_t n)     {return bound_t(n << 1);}
+        [[nodiscard]] static constexpr bound_t non_strict(val_t n) {return bound_t(~((~n) << 1));}
+        [[nodiscard]] static constexpr bound_t inf()               {return bound_t(INF_BOUND);}
+        [[nodiscard]] static constexpr bound_t le_zero()           {return bound_t(LE_ZERO_BOUND);}
+        [[nodiscard]] static constexpr bound_t lt_zero()           {return bound_t(LT_ZERO_BOUND);}
 
-        [[nodiscard]] static const bound_t& max(const bound_t &a, const bound_t &b);
-        [[nodiscard]] static bound_t max(bound_t &&a, bound_t &&b);
-        [[nodiscard]] static bound_t max(const bound_t &a, bound_t &&b);
-        [[nodiscard]] static bound_t max(bound_t &&a, const bound_t &b);
+        [[nodiscard]] inline val_t get_bound()    const {return this->_data >> 1;}
+        [[nodiscard]] inline bool is_strict()     const {return not this->is_non_strict();}
+        [[nodiscard]] inline bool is_non_strict() const {return this->_data << 31;}
+        [[nodiscard]] inline bool is_inf()        const {return this->_data & INF_BOUND;}
 
-        [[nodiscard]] static const bound_t& min(const bound_t &a, const bound_t &b);
-        [[nodiscard]] static bound_t min(bound_t &&a, bound_t &&b);
-        [[nodiscard]] static bound_t min(const bound_t &a, bound_t &&b);
-        [[nodiscard]] static bound_t min(bound_t &&a, const bound_t &b);
+        [[nodiscard]] static inline bound_t max(bound_t a, bound_t b) {return a < b ? b : a;}
+        [[nodiscard]] static inline bound_t min(bound_t a, bound_t b) {return a < b ? a : b;}
 
         [[nodiscard]] bound_t operator+(bound_t rhs) const;
         [[nodiscard]] bound_t operator+(val_t rhs) const;
@@ -73,13 +91,12 @@ namespace pardibaal {
 
         [[nodiscard]] bound_t operator*(val_t rhs) const;
 
-        [[nodiscard]] bool operator<(bound_t rhs) const;
-        [[nodiscard]] bool operator==(bound_t rhs) const;
-
-        [[nodiscard]] bool operator!=(bound_t rhs) const;
-        [[nodiscard]] bool operator>(bound_t rhs) const;
-        [[nodiscard]] bool operator>=(bound_t rhs) const;
-        [[nodiscard]] bool operator<=(bound_t rhs) const;
+        [[nodiscard]] inline bool operator==(bound_t rhs) const {return this->_data == rhs._data;}
+        [[nodiscard]] inline bool operator!=(bound_t rhs) const {return this->_data != rhs._data;}
+        [[nodiscard]] inline bool operator<(bound_t rhs)  const {return this->_data < rhs._data;}
+        [[nodiscard]] inline bool operator>(bound_t rhs)  const {return this->_data > rhs._data;}
+        [[nodiscard]] inline bool operator>=(bound_t rhs) const {return this->_data >= rhs._data;}
+        [[nodiscard]] inline bool operator<=(bound_t rhs) const {return this->_data <= rhs._data;}
 
         [[nodiscard]] bool operator==(val_t rhs) const;
         [[nodiscard]] bool operator!=(val_t rhs) const;

--- a/src/pardibaal/bound_t.h
+++ b/src/pardibaal/bound_t.h
@@ -45,7 +45,7 @@ namespace pardibaal {
     const int32_t BOUND_VAL_MAX = std::numeric_limits<int32_t>::max() >> 1;
     const int32_t BOUND_VAL_MIN = std::numeric_limits<int32_t>::min() >> 1;
 
-    enum strict_e {STRICT, NON_STRICT};
+    enum strict_e {STRICT = 0, NON_STRICT = 1};
 
     struct bound_t {
 
@@ -57,17 +57,11 @@ namespace pardibaal {
     public:
         constexpr bound_t(){};
         constexpr bound_t(val_t n, strict_e strictness) {
-            if (strictness == STRICT)
-                _data = n << 1;
-            else
-                _data = ~((~n) << 1);
+            _data = (n << 1) | (val_t) strictness;
         }
 
         constexpr bound_t(val_t n, bool strict) {
-            if (strict)
-                _data = n << 1;
-            else
-                _data = ~((~n) << 1);
+            _data = (n << 1) | (val_t) !strict;
         }
 
         [[nodiscard]] static constexpr bound_t strict(val_t n)     {return bound_t(n << 1);}

--- a/test/DBM_test.cpp
+++ b/test/DBM_test.cpp
@@ -93,12 +93,12 @@ BOOST_AUTO_TEST_CASE(bounded_future_test_3) {
         for (dim_t j = 0; j < 10; j++) {               
             if (j == 0 && i != 0) {
                 if (i == 2)
-                    BOOST_CHECK(D.at(i, j) == bound_t::inf() && D.at(i,j).get_bound() == 0);
+                    BOOST_CHECK(D.at(i, j) == bound_t::inf());
                 else
                     BOOST_CHECK(D.at(i, j) == bound_t::non_strict(5));
             } else {
                 if (i == 2 && j != 2)
-                    BOOST_CHECK(D.at(i, j) == bound_t::inf() && D.at(i, j).get_bound() == 0);
+                    BOOST_CHECK(D.at(i, j) == bound_t::inf());
                 else
                     BOOST_CHECK(D.at(i, j) == bound_t::le_zero());
             }

--- a/test/DBM_test.cpp
+++ b/test/DBM_test.cpp
@@ -837,6 +837,28 @@ BOOST_AUTO_TEST_CASE(extrapolate_lu_diagonal_test_1) {
     BOOST_CHECK(D.at(2, 2) == bound_t::le_zero());
 }
 
+BOOST_AUTO_TEST_CASE(extrapolate_lu_diagonal_test_2) {
+    DBM D(3);
+    D.set(0, 1, bound_t::non_strict(-2));
+    D.set(0, 2, bound_t::non_strict(-2));
+    D.set(1, 0, bound_t::non_strict(5));
+    D.set(1, 2, bound_t::le_zero());
+    D.set(2, 0, bound_t::non_strict(7));
+    D.set(2, 1, bound_t::non_strict(2));
+
+    std::vector<val_t> upper {0, 10, 10};
+    std::vector<val_t> lower {0, 5, 5};
+
+    D.extrapolate_lu_diagonal(lower, upper);
+
+    BOOST_CHECK(D.at(0, 1) == bound_t::non_strict(-2));
+    BOOST_CHECK(D.at(0, 2) == bound_t::non_strict(-2));
+    BOOST_CHECK(D.at(1, 0) == bound_t::non_strict(5));
+    BOOST_CHECK(D.at(1, 2) == bound_t::le_zero());
+    BOOST_CHECK(D.at(2, 0) == bound_t::non_strict(7));
+    BOOST_CHECK(D.at(2, 1) == bound_t::non_strict(2));
+}
+
 BOOST_AUTO_TEST_CASE(intersection_test_1) {
     auto dbm1 = DBM::zero(3);
     auto dbm2 = DBM::zero(3);

--- a/test/bound_test.cpp
+++ b/test/bound_test.cpp
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(add_test_5) {
 
     BOOST_CHECK(a + 5 == b);
     BOOST_CHECK(b == bound_t::inf());
-    BOOST_CHECK(b.get_bound() == 0);
+    // BOOST_CHECK(b.get_bound() == 0);
 }
 
 BOOST_AUTO_TEST_CASE(add_test_6) {
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(subtract_test_3) {
     auto b = a - 5;
 
     BOOST_CHECK(b == bound_t::inf());
-    BOOST_CHECK(b.get_bound() == 0);
+    // BOOST_CHECK(b.get_bound() == 0);
 }
 
 BOOST_AUTO_TEST_CASE(multiply_test_1) {
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(multiply_test_2) {
     auto b = a * 5;
 
     BOOST_CHECK(b == bound_t::inf());
-    BOOST_CHECK(b.get_bound() == 0);
+    // BOOST_CHECK(b.get_bound() == 0);
 }
 
 BOOST_AUTO_TEST_CASE(comp_test_6) {

--- a/test/difference_bound_test.cpp
+++ b/test/difference_bound_test.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(inf_test_1) {
 
     BOOST_CHECK(c._i == 10);
     BOOST_CHECK(c._j == 3);
-    BOOST_CHECK(c._bound.is_strict());
+    BOOST_CHECK(c._bound.is_non_strict());
     BOOST_CHECK(c._bound.is_inf());
 }
 


### PR DESCRIPTION
Compress bound_t struct to 32 bits.
Optimize some methods with fewer dimension calls and diagonal extrapolation to go through fewer bounds when closing. Also remove a full dbm copy from diagonal extrapolation.